### PR TITLE
Remove unnecessary Const

### DIFF
--- a/src/sort/merge_sort.jl
+++ b/src/sort/merge_sort.jl
@@ -1,4 +1,4 @@
-@kernel inbounds=true function _merge_sort_block!(vec, @Const(comp))
+@kernel inbounds=true function _merge_sort_block!(vec, comp)
 
     N = @groupsize()[1]
     s_buf = @localmem eltype(vec) (N * 2,)
@@ -75,7 +75,7 @@
 end
 
 
-@kernel inbounds=true function _merge_sort_global!(@Const(vec_in), vec_out, @Const(comp), @Const(half_size_group))
+@kernel inbounds=true function _merge_sort_global!(@Const(vec_in), vec_out, comp, half_size_group)
 
     len = length(vec_in)
     N = @groupsize()[1]

--- a/src/sort/merge_sort_by_key.jl
+++ b/src/sort/merge_sort_by_key.jl
@@ -1,4 +1,4 @@
-@kernel inbounds=true function _merge_sort_by_key_block!(keys, values, @Const(comp))
+@kernel inbounds=true function _merge_sort_by_key_block!(keys, values, comp)
 
     N = @groupsize()[1]
     s_keys = @localmem eltype(keys) (N * 2,)
@@ -99,7 +99,7 @@ end
 
 @kernel inbounds=true function _merge_sort_by_key_global!(@Const(keys_in), keys_out,
                                                           @Const(values_in), values_out,
-                                                          @Const(comp), @Const(half_size_group))
+                                                          comp, half_size_group)
 
     len = length(keys_in)
     N = @groupsize()[1]


### PR DESCRIPTION
Fixes #2.

`@Const` on `half_size_group` is not needed, since it is an integer.
`@Const` on comparator function does not play well with AMDGPU for some reason (and I'm not sure it is needed), especially if it is a closure.

With these changes all tests on RX 7900XTX pass.
We probably should set up CI for testing.