### PR TITLE
Update deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AcceleratedKernels"
 uuid = "6a4ca0a5-0e36-4168-a932-d9be78d558f1"
 authors = ["Andrei-Leonard Nicusan <leonard@evophase.co.uk> and contributors"]
-version = "0.2.0-DEV"
+version = "0.2.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -15,9 +15,9 @@ Unrolled = "9602ed7d-8fef-5bc8-8597-8f21381861e8"
 [compat]
 ArgCheck = "2.1"
 DocStringExtensions = "0.9"
-GPUArraysCore = "0.1"
+GPUArraysCore = "0.2"
 KernelAbstractions = "0.9"
-Markdown = "1.11"
+Markdown = "1.10"
 Polyester = "0.7"
 Unrolled = "0.1.5"
-julia = "1.6.7"
+julia = "1.10"


### PR DESCRIPTION
- Update `GPUArraysCore@0.2` to support `GPUArrays@11.1`.
- Bump min Julia version to `1.10`. All GPU backends have switched to this.

Can we also register a new version of it (I set version to `0.2` as well)?