### PR TITLE
Fix CPU CI

### DIFF
--- a/.github/workflows/CI-CPU.yml
+++ b/.github/workflows/CI-CPU.yml
@@ -31,15 +31,27 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+          - macOS-13
         arch:
           - x64
           - x86
+          - aarch64
         env:
           - JULIA_NUM_THREADS: 1
           - JULIA_NUM_THREADS: 2
         exclude:
+          - os: macOS-13
+            arch: x86
+          - os: macOS-13
+            arch: aarch64
           - os: macOS-latest
             arch: x86
+          - os: macOS-latest
+            arch: x64
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: windows-latest
+            arch: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI-CPU.yml
+++ b/.github/workflows/CI-CPU.yml
@@ -49,6 +49,8 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          JULIA_NUM_THREADS: ${{ matrix.env.JULIA_NUM_THREADS }}
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -274,12 +274,12 @@ function _mapreduce_impl(
             if num_tasks <= 1
                 return Base.mapreduce(f, op, src; init=init)
             end
-            return OMT.tmapreduce(
-                f, op, src, init=init,
+            return op(init, OMT.tmapreduce(
+                f, op, src; init=neutral,
                 scheduler=scheduler,
                 outputtype=typeof(init),
                 nchunks=num_tasks,
-            )
+            ))
         else
             # FIXME: waiting on OhMyThreads.jl for n-dimensional reduction
             return Base.mapreduce(f, op, src; init=init, dims=dims)


### PR DESCRIPTION
The 2-thread tests were running on only 1 thread. This hid issue #28.

Secondly, the "x64" macos tests were actually running on aarch64 since only the `macos-13` runners still have the x64 architecture available. I also added tests to officially test aarch64 macOS, since that's the more common configuration nowadays.

2-thread tests will fail until #28 is resolved. 