### PR TITLE
Add KA 0.10 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AcceleratedKernels"
 uuid = "6a4ca0a5-0e36-4168-a932-d9be78d558f1"
 authors = ["Andrei-Leonard Nicusan <leonard@evophase.co.uk> and contributors"]
-version = "0.4.4"
+version = "0.4.3"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AcceleratedKernels"
 uuid = "6a4ca0a5-0e36-4168-a932-d9be78d558f1"
 authors = ["Andrei-Leonard Nicusan <leonard@evophase.co.uk> and contributors"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -19,7 +19,7 @@ AcceleratedKernelsoneAPIExt = "oneAPI"
 [compat]
 ArgCheck = "2"
 GPUArraysCore = "0.2.0"
-KernelAbstractions = "0.9.34"
+KernelAbstractions = "0.9.34, 0.10"
 Markdown = "1"
 UnsafeAtomics = "0.3.0"
 julia = "1.10"

--- a/test/generic/looping.jl
+++ b/test/generic/looping.jl
@@ -3,7 +3,7 @@
     Random.seed!(0)
 
     # CPU
-    if IS_CPU_BACKEND && prefer_threads
+    if prefer_threads
         x = zeros(Int, 1000)
         AK.foreachindex(x; prefer_threads) do i
             x[i] = i

--- a/test/generic/map.jl
+++ b/test/generic/map.jl
@@ -2,7 +2,7 @@
     Random.seed!(0)
 
     # CPU
-    if IS_CPU_BACKEND && prefer_threads
+    if prefer_threads
         x = Array(1:1000)
         y = AK.map(x; prefer_threads) do i
             i^2

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -131,7 +131,7 @@ Base.zero(::Type{Point}) = Point(0.0f0, 0.0f0)
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.reduce(+, array_from_host(rand(Int32, 10)); init=10, bad=:kwarg)
-    if !IS_CPU_BACKEND
+    if !prefer_threads
         @test_throws ArgumentError AK.reduce(+, array_from_host(rand(Int32, 256)); prefer_threads, init=Int32(0), block_size=192)
     end
 
@@ -279,7 +279,7 @@ end
             sum(vh; init=Int32(0), dims)
     end
 
-    if IS_CPU_BACKEND
+    if prefer_threads
         # The CPU fallback should not require strided storage.
         vh = reshape(1:12, 1, 3, 4)
         @test Array(AK.reduce(+, vh, BACKEND; prefer_threads, init=0, dims=(1,2))) ==
@@ -302,7 +302,7 @@ end
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.reduce(+, array_from_host(rand(Int32, 10, 10)); prefer_threads, init=10, bad=:kwarg)
-    if !IS_CPU_BACKEND
+    if !prefer_threads
         @test_throws ArgumentError AK.reduce(+, array_from_host(rand(Int32, 16, 16)); prefer_threads, init=Int32(0), dims=1, block_size=192)
     end
 
@@ -483,7 +483,7 @@ end
         init=Int32(0),
     )
 
-    if IS_CPU_BACKEND
+    if prefer_threads
         bc = Base.Broadcast.instantiate(Base.Broadcast.broadcasted(+, reshape(1:6, 2, 3), reshape(10:15, 2, 3)))
         @test AK.mapreduce(identity, +, bc; prefer_threads, init=0) ==
             mapreduce(identity, +, bc; init=0)
@@ -513,7 +513,7 @@ end
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.mapreduce(-, +, v; prefer_threads, init=10, bad=:kwarg)
-    if !IS_CPU_BACKEND
+    if !prefer_threads
         @test_throws ArgumentError AK.mapreduce(-, +, array_from_host(rand(Int32, 256)); prefer_threads, init=Int32(0), block_size=192)
     end
 end
@@ -679,7 +679,7 @@ end
             mapreduce(x -> x - Int32(1), +, vh; init=Int32(0), dims)
     end
 
-    if IS_CPU_BACKEND
+    if prefer_threads
         # The CPU fallback should not require strided storage.
         vh = reshape(1:12, 1, 3, 4)
         @test Array(AK.mapreduce(x -> 2x, +, vh, BACKEND; prefer_threads, init=0, dims=(1,2))) ==
@@ -700,7 +700,7 @@ end
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.mapreduce(-, +, array_from_host(rand(Int32, 3, 4, 5)); prefer_threads, init=10, bad=:kwarg)
-    if !IS_CPU_BACKEND
+    if !prefer_threads
         @test_throws ArgumentError AK.mapreduce(-, +, array_from_host(rand(Int32, 16, 16)); prefer_threads, init=Int32(0), dims=1, block_size=192)
     end
 

--- a/test/generic/sort.jl
+++ b/test/generic/sort.jl
@@ -1,4 +1,4 @@
-if !IS_CPU_BACKEND || !prefer_threads
+if !prefer_threads
 @testset "merge_sort" begin
     Random.seed!(0)
 
@@ -229,7 +229,7 @@ end
         issorted(vh[ixh]; kwargs...)
     end
 
-    if !IS_CPU_BACKEND || !prefer_threads
+    if !prefer_threads
         for T in filter(T -> T !== Float64 || KernelAbstractions.supports_float64(BACKEND),
                         (UInt32, Int32, Float32, UInt64, Int64, Float64))
             v_h = rand(T, 10_000)
@@ -277,7 +277,7 @@ end
 end
 
 
-if !IS_CPU_BACKEND || !prefer_threads
+if !prefer_threads
 @testset "merge_sort_by_key" begin
     Random.seed!(0)
 
@@ -359,7 +359,7 @@ end
 end
 
 
-if !IS_CPU_BACKEND || !prefer_threads
+if !prefer_threads
 @testset "merge_sortperm" begin
     Random.seed!(0)
 
@@ -468,7 +468,7 @@ end
 end
 
 
-if !IS_CPU_BACKEND || !prefer_threads
+if !prefer_threads
 @testset "merge_sortperm_lowmem" begin
     Random.seed!(0)
 
@@ -586,7 +586,7 @@ end
 end
 
 
-if !IS_CPU_BACKEND || !prefer_threads
+if !prefer_threads
 @testset "sortperm_extended" begin
     # Helper: ix is a valid permutation of 1:n that produces a sorted order
     function is_valid_perm(vh, ixh; kwargs...)
@@ -698,7 +698,7 @@ if !IS_CPU_BACKEND || !prefer_threads
 end
 
 @testset "radix_sort_alg" begin
-    if !IS_CPU_BACKEND || !prefer_threads
+    if !prefer_threads
         Random.seed!(0)
 
         # ── Correctness: fuzzy testing across supported types ─────────────────

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,10 +23,15 @@ const _array_from_host_code = quote
     global array_from_host
     array_from_host(h_arr::AbstractArray, dtype=nothing) = array_from_host(BACKEND, h_arr, dtype)
     function array_from_host(backend, h_arr::AbstractArray, dtype=nothing)
-        d_arr = KernelAbstractions.zeros(backend, isnothing(dtype) ? eltype(h_arr) : dtype, size(h_arr))
+        d_arr = d_arr = if IS_CPU_BACKEND && prefer_threads # Don't use KA zeros if not using KA algorithms
+            zeros(isnothing(dtype) ? eltype(h_arr) : dtype, size(h_arr))
+        else
+            KernelAbstractions.zeros(backend, isnothing(dtype) ? eltype(h_arr) : dtype, size(h_arr))
+        end
         copyto!(d_arr, h_arr isa Array ? h_arr : Array(h_arr))
         d_arr
     end
+
 end
 
 # Build list of active backends, each with setup code

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,6 @@ const _array_from_host_code = quote
         copyto!(d_arr, h_arr isa Array ? h_arr : Array(h_arr))
         d_arr
     end
-
 end
 
 # Build list of active backends, each with setup code


### PR DESCRIPTION
This package has supported KA 0.10 since #56 since most of the breaking changes are for the backend implementations. This makes it much easier to test the backends that already have AcceleratedKernels as a dependency (AMDGPU.jl and oneAPI.jl.

Once KA 0.10 is officially released and we move to the KernelIntrinsics API we'll have to drop support for KA 0.9 but until then having both supported makes it much easier to run CI