### PR TITLE
Expand dimensional `mapreduce` / `reduce`

### DIFF
--- a/src/arithmetics.jl
+++ b/src/arithmetics.jl
@@ -2,7 +2,7 @@
     sum(
         src::AbstractArray, backend::Backend=get_backend(src);
         init=zero(eltype(src)),
-        dims::Union{Nothing, Int}=nothing,
+        dims::Union{Nothing, Int, Tuple{Vararg{Int}}, Colon}=nothing,
 
         # CPU settings
         max_tasks=Threads.nthreads(),
@@ -58,7 +58,7 @@ end
     prod(
         src::AbstractArray, backend::Backend=get_backend(src);
         init=one(eltype(src)),
-        dims::Union{Nothing, Int}=nothing,
+        dims::Union{Nothing, Int, Tuple{Vararg{Int}}, Colon}=nothing,
 
         # CPU settings
         max_tasks=Threads.nthreads(),
@@ -114,7 +114,7 @@ end
     maximum(
         src::AbstractArray, backend::Backend=get_backend(src);
         init=typemin(eltype(src)),
-        dims::Union{Nothing, Int}=nothing,
+        dims::Union{Nothing, Int, Tuple{Vararg{Int}}, Colon}=nothing,
 
         # CPU settings
         max_tasks=Threads.nthreads(),
@@ -170,7 +170,7 @@ end
     minimum(
         src::AbstractArray, backend::Backend=get_backend(src);
         init=typemax(eltype(src)),
-        dims::Union{Nothing, Int}=nothing,
+        dims::Union{Nothing, Int, Tuple{Vararg{Int}}, Colon}=nothing,
 
         # CPU settings
         max_tasks=Threads.nthreads(),
@@ -226,7 +226,7 @@ end
     count(
         [f=identity], src::AbstractArray, backend::Backend=get_backend(src);
         init=0,
-        dims::Union{Nothing, Int}=nothing,
+        dims::Union{Nothing, Int, Tuple{Vararg{Int}}, Colon}=nothing,
 
         # CPU settings
         max_tasks=Threads.nthreads(),

--- a/src/arithmetics.jl
+++ b/src/arithmetics.jl
@@ -33,11 +33,11 @@ m = MtlArray(rand(Int32(1):Int32(100), 10, 100_000))
 s = AK.sum(m, dims=1)
 ```
 
-If you know the shape of the resulting array (in case of a axis-wise sum, i.e. `dims` is not
+If you know the shape of the resulting array (in case of a dimensionwise sum, i.e. `dims` is not
 `nothing`), you can provide the `temp` argument to save results into and avoid allocations:
 ```julia
 m = MtlArray(rand(Int32(1):Int32(100), 10, 100_000))
-temp = MtlArray(zeros(Int32, 10))
+temp = MtlArray(zeros(Int32, 10, 1))
 s = AK.sum(m, dims=2, temp=temp)
 ```
 """
@@ -89,11 +89,11 @@ m = ROCArray(rand(Int32(1):Int32(100), 10, 100_000))
 p = AK.prod(m, dims=1)
 ```
 
-If you know the shape of the resulting array (in case of a axis-wise product, i.e. `dims` is not
+If you know the shape of the resulting array (in case of a dimensionwise product, i.e. `dims` is not
 `nothing`), you can provide the `temp` argument to save results into and avoid allocations:
 ```julia
 m = ROCArray(rand(Int32(1):Int32(100), 10, 100_000))
-temp = ROCArray(ones(Int32, 10))
+temp = ROCArray(ones(Int32, 10, 1))
 p = AK.prod(m, dims=2, temp=temp)
 ```
 """
@@ -145,11 +145,11 @@ m = oneArray(rand(Int32(1):Int32(100), 10, 100_000))
 m = AK.maximum(m, dims=1)
 ```
 
-If you know the shape of the resulting array (in case of a axis-wise maximum, i.e. `dims` is not
+If you know the shape of the resulting array (in case of a dimensionwise maximum, i.e. `dims` is not
 `nothing`), you can provide the `temp` argument to save results into and avoid allocations:
 ```julia
 m = oneArray(rand(Int32(1):Int32(100), 10, 100_000))
-temp = oneArray(zeros(Int32, 10))
+temp = oneArray(zeros(Int32, 10, 1))
 m = AK.maximum(m, dims=2, temp=temp)
 ```
 """
@@ -201,11 +201,11 @@ m = CuArray(rand(Int32(1):Int32(100), 10, 100_000))
 m = AK.minimum(m, dims=1)
 ```
 
-If you know the shape of the resulting array (in case of a axis-wise minimum, i.e. `dims` is not
+If you know the shape of the resulting array (in case of a dimensionwise minimum, i.e. `dims` is not
 `nothing`), you can provide the `temp` argument to save results into and avoid allocations:
 ```julia
 m = CuArray(rand(Int32(1):Int32(100), 10, 100_000))
-temp = CuArray(ones(Int32, 10))
+temp = CuArray(ones(Int32, 10, 1))
 m = AK.minimum(m, dims=2, temp=temp)
 ```
 """
@@ -263,12 +263,12 @@ m = MtlArray(rand(Bool, 10, 100_000))
 c = AK.count(m, dims=1)
 ```
 
-If you know the shape of the resulting array (in case of a axis-wise count, i.e. `dims` is not
+If you know the shape of the resulting array (in case of a dimensionwise count, i.e. `dims` is not
 `nothing`), you can provide the `temp` argument to save results into and avoid allocations:
 ```julia
 m = MtlArray(rand(Bool, 10, 100_000))
-temp = MtlArray(zeros(Int32, 10))
-c = AK.count(m, dims=2, temp=temp)
+temp = MtlArray(zeros(Int32, 10, 1))
+c = AK.count(m; init=Int32(0), dims=2, temp=temp)
 ```
 """
 function count(

--- a/src/reduce/mapreduce_1d_cpu.jl
+++ b/src/reduce/mapreduce_1d_cpu.jl
@@ -1,5 +1,5 @@
 function mapreduce_1d_cpu(
-    f, op, src::AbstractArray, backend::Backend;
+    f, op, src::MapReduceSource, backend::Backend;
     init,
     neutral,
 
@@ -12,6 +12,10 @@ function mapreduce_1d_cpu(
     temp::Union{Nothing, AbstractArray},
     switch_below::Int,
 )
+    if src isa Base.Broadcast.Broadcasted
+        return op(init, Base.mapreduce(f, op, src; init=neutral))
+    end
+
     if max_tasks == 1
         return op(init, Base.mapreduce(f, op, src; init=neutral))
     end

--- a/src/reduce/mapreduce_1d_gpu.jl
+++ b/src/reduce/mapreduce_1d_gpu.jl
@@ -61,6 +61,7 @@ function mapreduce_1d_gpu(
     switch_below::Int,
 )
     @argcheck 1 <= block_size <= 1024
+    @argcheck ispow2(block_size)
     @argcheck switch_below >= 0
 
     # Degenerate cases

--- a/src/reduce/mapreduce_1d_gpu.jl
+++ b/src/reduce/mapreduce_1d_gpu.jl
@@ -47,7 +47,7 @@ end
 
 
 function mapreduce_1d_gpu(
-    f, op, src::AbstractArray, backend::Backend;
+    f, op, src::MapReduceSource, backend::Backend;
     init,
     neutral,
 
@@ -87,8 +87,8 @@ function mapreduce_1d_gpu(
         dst = KernelAbstractions.allocate(backend, dst_type, blocks * 2)
     end
 
-    # Later the kernel will be compiled for views anyways, so use same types
-    src_view = @view src[1:end]
+    # Later the kernel will be compiled for views anyways, so use same types for arrays.
+    src_view = _mapreduce_1d_src_view(src)
     dst_view = @view dst[1:blocks]
 
     kernel! = _mapreduce_block!(backend, block_size)
@@ -125,3 +125,6 @@ function mapreduce_1d_gpu(
     # The GPU kernel reduced all elements to one, but without the init value
     return op(init, @allowscalar(p1[1]))
 end
+
+_mapreduce_1d_src_view(src::AbstractArray) = @view src[1:end]
+_mapreduce_1d_src_view(src::Base.Broadcast.Broadcasted) = src

--- a/src/reduce/mapreduce_1d_gpu.jl
+++ b/src/reduce/mapreduce_1d_gpu.jl
@@ -66,7 +66,7 @@ function mapreduce_1d_gpu(
     # Degenerate cases
     len = length(src)
     len == 0 && return init
-    len == 1 && return @allowscalar f(src[1])
+    len == 1 && return op(init, @allowscalar f(src[1]))
     if len < switch_below
         h_src = Vector(src)
         return Base.mapreduce(f, op, h_src; init)

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -82,14 +82,11 @@ function mapreduce_nd(
         throw(ArgumentError("region dimension(s) must be ≥ 1, got $dims"))
     end
 
-    # Duplicate dims check: Base errors on dims=(2,2)
-    if length(dims_all) != length(Base.unique(dims_all))
-        throw(ArgumentError("region dimension(s) must be unique, got $dims"))
-    end
+    # Match Base: duplicate dims are ignored, e.g. dims=(2,2) behaves like dims=2.
+    dims_all = Tuple(Base.unique(dims_all))
 
-    src_sizes   = size(src)
-    src_strides = strides(src)
-    ndim        = length(src_sizes)
+    src_sizes = size(src)
+    ndim      = length(src_sizes)
 
     dims_valid = Tuple(d for d in dims_all if d <= ndim)
 
@@ -140,11 +137,12 @@ function mapreduce_nd(
     dst = _alloc_or_temp(backend, temp, init, dst_sizes)
     dst_size = length(dst)
 
-    if !use_gpu_algorithm(backend, prefer_threads)
+    if backend == CPU_BACKEND
         _mapreduce_nd_cpu_sections!(f, op, dst, src; init, max_tasks, min_elems)
         return dst
     end
 
+    src_strides = strides(src)
     reduce_segs, outer_segs = _canonicalize_dims(src_sizes, src_strides, dims_valid)
 
     outer_strides  = Tuple(str for (str, _) in outer_segs)
@@ -505,4 +503,3 @@ end
         end
     end
 end
-

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -1,10 +1,15 @@
+# Generalized N-dimensional mapreduce for GPU and CPU backends.
+# Uses stride-arithmetic-based indexing (no CartesianIndices in GPU kernels)
+# with multi-group reduction for large reduction dimensions.
+# Note: This file was developed with AI assistance (Claude, Anthropic).
+
 function mapreduce_nd(
     f, op, src::AbstractArray, backend::Backend;
     init,
     neutral=neutral_element(op, eltype(src)),
     dims::Union{Int, Tuple{Vararg{Int}}},
 
-    # CPU settings - ignored here
+    # CPU settings
     max_tasks::Int,
     min_elems::Int,
     prefer_threads::Bool=true,
@@ -15,19 +20,23 @@ function mapreduce_nd(
 )
     @argcheck 1 <= block_size <= 1024
 
-    # Degenerate cases begin; order of priority matters
+    # Normalize dims to a tuple
+    dims_all = dims isa Int ? (dims,) : dims
 
-    # Invalid dims
-    if Base.any(d < 1 for d in (dims isa Int ? (dims,) : dims))
+    # Invalid dims: negative or zero
+    if Base.any(d < 1 for d in dims_all)
         throw(ArgumentError("region dimension(s) must be ≥ 1, got $dims"))
     end
 
-    # If dims > number of dimensions, just map each element through f and add init, e.g.:
-    #   julia> x = rand(Float64, 3, 5);
-    #   julia> mapreduce(x -> -x, +, x, dims=3, init=Float32(0))
-    #   3×5 Matrix{Float32}     # Negative numbers
     src_sizes = size(src)
-    if Base.all(d > length(src_sizes) for d in (dims isa Int ? (dims,) : dims))
+    ndim = length(src_sizes)
+
+    # Filter out-of-range dims (Base silently ignores them)
+    # e.g. dims=(1,4) on a 3D array → only dim 1 is reduced
+    dims_valid = Tuple(d for d in dims_all if d <= ndim)
+
+    # If ALL dims are out of range, just map each element through f and add init
+    if isempty(dims_valid)
         if isnothing(temp)
             dst = KernelAbstractions.allocate(backend, typeof(init), src_sizes)
         else
@@ -40,18 +49,14 @@ function mapreduce_nd(
         return dst
     end
 
-    # The per-dimension sizes of the destination array; construct tuple without allocations
+    # Destination sizes: reduced dims become 1
     dst_sizes = unrolled_map_index(src_sizes) do i
-        i in dims ? 1 : src_sizes[i]
+        i in dims_valid ? 1 : src_sizes[i]
     end
 
-    # If any dimension except dims is zero, return empty similar array except with the dims
-    # dimension = 1. Weird, see example below:
-    #   julia> x = rand(3, 0, 5);
-    #   julia> reduce(+, x, dims=3)
-    #   3×0×1 Array{Float64, 3}
+    # If any kept dimension is zero → return empty array
     for isize in eachindex(src_sizes)
-        isize in dims && continue
+        isize in dims_valid && continue
         if src_sizes[isize] == 0
             if isnothing(temp)
                 dst = KernelAbstractions.allocate(backend, typeof(init), dst_sizes)
@@ -64,16 +69,10 @@ function mapreduce_nd(
         end
     end
 
-    # If sizes[dims] == 0, return array filled with init; same shape except sizes[dims] = 1:
-    #   julia> x = rand(3, 0, 5);
-    #   julia> mapreduce(+, x, dims=2)
-    #   3×1×5 Array{Float64, 3}:
-    #   [:, :, 1] =
-    #    0.0
-    #    0.0
-    #    0.0
-    #   [...]
-    len = Base.prod(src_sizes[d] for d in (dims isa Int ? (dims,) : dims))
+    # Total number of elements being reduced per output element
+    len = Base.prod(src_sizes[d] for d in dims_valid)
+
+    # If reduced dims are all zero → fill with init
     if len == 0
         if isnothing(temp)
             dst = KernelAbstractions.allocate(backend, typeof(init), dst_sizes)
@@ -87,7 +86,7 @@ function mapreduce_nd(
         return dst
     end
 
-    # If sizes[dims] == 1, just map each element through f. Again, keep same type as init
+    # If reduced dims are all 1 → just apply f element-wise
     if len == 1
         if isnothing(temp)
             dst = KernelAbstractions.allocate(backend, typeof(init), src_sizes)
@@ -101,9 +100,7 @@ function mapreduce_nd(
         return dst
     end
 
-    # Degenerate cases end
-
-    # Allocate destination array
+    # Allocate destination
     if isnothing(temp)
         dst = KernelAbstractions.allocate(backend, typeof(init), dst_sizes)
     else
@@ -118,35 +115,89 @@ function mapreduce_nd(
         _mapreduce_nd_cpu_sections!(
             f, op, dst, src;
             init,
+            dims=dims_valid,
             max_tasks=max_tasks,
             min_elems=min_elems,
         )
     else
-        Rother  = CartesianIndices(dst)
-        Rreduce = CartesianIndices(ifelse.(axes(src) .== axes(dst), Ref(Base.OneTo(1)), axes(src)))
+        # Precompute strides on host — passed as tuples to kernel
+        # This avoids CartesianIndices div/mod inside the kernel
+        src_str = strides(src)
+        dst_str = strides(dst)
+
+        # reduce_strides: for each src dim, its stride if it's a reduced dim, else 0
+        # Used to walk through the reduced subspace
+        reduce_str = unrolled_map_index(src_str) do i
+            i in dims_valid ? src_str[i] : 0
+        end
 
         if dst_size >= len
+            # More output elements than reduction elements → one thread per output
             blocks = (dst_size + block_size - 1) ÷ block_size
             kernel1! = _mapreduce_nd_by_thread!(backend, block_size)
             kernel1!(
-                src, dst, f, op, init, Rother, Rreduce,
+                src, dst, f, op, init,
+                src_str, dst_str, reduce_str,
+                dst_size, len, ndim,
                 ndrange=(block_size * blocks,),
             )
         else
-            blocks = dst_size
-            kernel2! = _mapreduce_nd_by_block!(backend, block_size)
-            kernel2!(
-                src, dst, f, op, init, neutral, Rother, Rreduce,
-                ndrange=(block_size * blocks,),
-            )
+            # More reduction elements than output elements → one block per output
+            reduce_groups = (len + block_size - 1) ÷ block_size
+
+            if reduce_groups == 1
+                # Single group — all threads in one block handle one output element
+                kernel2! = _mapreduce_nd_by_block!(backend, block_size)
+                kernel2!(
+                    src, dst, f, op, init, neutral,
+                    src_str, dst_str, reduce_str,
+                    dst_size, len, ndim,
+                    ndrange=(block_size * dst_size,),
+                )
+            else
+                # Multi-group — multiple blocks per output element
+                # partial shape: (dst_sizes..., reduce_groups)
+                partial_sizes = (dst_sizes..., reduce_groups)
+                partial = KernelAbstractions.allocate(backend, typeof(init), partial_sizes)
+
+                partial_str = strides(partial)
+
+                kernel3! = _mapreduce_nd_by_block_multigroup!(backend, block_size)
+                kernel3!(
+                    src, partial, f, op, neutral,
+                    src_str, dst_str, reduce_str, partial_str,
+                    dst_size, len, reduce_groups, ndim,
+                    ndrange=(block_size * dst_size * reduce_groups,),
+                )
+
+                # Second pass: reduce partial → dst
+                # partial has shape (dst_sizes..., reduce_groups)
+                # treat last dim as the reduction dim
+                partial_dst_str = strides(partial)[1:ndim]  # strides of first ndim dims
+                reduce_str2 = unrolled_map_index(strides(partial)) do i
+                    i == ndim + 1 ? strides(partial)[ndim + 1] : 0
+                end
+
+                kernel4! = _mapreduce_nd_by_block!(backend, block_size)
+                kernel4!(
+                    partial, dst, identity, op, init, neutral,
+                    strides(partial), dst_str, reduce_str2,
+                    dst_size, reduce_groups, ndim + 1,
+                    ndrange=(block_size * dst_size,),
+                )
+            end
         end
     end
+
     return dst
 end
 
+
+# CPU path — CartesianIndices is fine here
 function _mapreduce_nd_cpu_sections!(
     f, op, dst, src;
     init,
+    dims,
     max_tasks, min_elems,
 )
     Rother  = CartesianIndices(dst)
@@ -167,70 +218,164 @@ function _mapreduce_nd_cpu_sections!(
     dst
 end
 
+
+# GPU kernel: one thread per output element
+# Uses stride arithmetic — no CartesianIndices
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_thread!(
     @Const(src), dst,
-    f, op,
-    init, Rother, Rreduce,
+    f, op, init,
+    src_str, dst_str, reduce_str,
+    output_size, reduce_size, ndim,
 )
-    # One thread per output element, when there are more outer elements than in the reduced dims
-    output_size = length(Rother)
-    reduce_size = length(Rreduce)
-
     N = @groupsize()[1]
-
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
-
     tid = ithread + iblock * N
-    if tid < output_size
-        Iother = Rother[tid + 0x1]
 
-        res = init
-        for i in 0x1:reduce_size
-            Ireduce = Rreduce[i]
-            J = max(Iother, Ireduce)
-            res = op(res, f(src[J]))
+    if tid < output_size
+        # Compute base index in src for this output element
+        # Walk dst linear index → per-dim indices → src offset (skip reduced dims)
+        input_base_idx = typeof(ithread)(0)
+        tmp = tid
+        KernelAbstractions.Extras.@unroll for i in ndim:-1i16:1i16
+            if dst_str[i] > 0 && reduce_str[i] == 0
+                # This is a kept dim
+                dim_idx = tmp ÷ dst_str[i]
+                input_base_idx += dim_idx * src_str[i]
+            end
+            tmp = tmp % dst_str[i]
         end
-        dst[Iother] = res
+
+        # Walk through reduced subspace using reduce_str
+        res = init
+        for j in 0x0:reduce_size - 0x1
+            reduce_offset = typeof(ithread)(0)
+            tmp2 = j
+            KernelAbstractions.Extras.@unroll for i in ndim:-1i16:1i16
+                if reduce_str[i] > 0
+                    reduce_offset += (tmp2 ÷ (reduce_str[i] ÷ src_str[1])) * src_str[i]
+                    tmp2 = tmp2 % (reduce_str[i] ÷ src_str[1])
+                end
+            end
+            res = op(res, f(src[input_base_idx + reduce_offset + 0x1]))
+        end
+
+        dst[tid + 0x1] = res
     end
 end
 
+
+# GPU kernel: one block per output element, single group
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_block!(
     @Const(src), dst,
-    f, op,
-    init, neutral,
-    Rother, Rreduce,
+    f, op, init, neutral,
+    src_str, dst_str, reduce_str,
+    output_size, reduce_size, ndim,
 )
-    # One block per output element, when there are more elements in the reduced dims than outer
-    # e.g. reduce(+, rand(3, 1000), dims=2) => only 3 elements in outer dimensions
-    reduce_size = length(Rreduce)
-
     @uniform N = @groupsize()[1]
     sdata = @localmem eltype(dst) (N,)
 
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
 
-    # Each block handles one output element
-    Iother = Rother[iblock + 0x1]
+    if iblock < output_size
+        # Compute base index in src for this output element
+        input_base_idx = typeof(ithread)(0)
+        tmp = iblock
+        KernelAbstractions.Extras.@unroll for i in ndim:-1i16:1i16
+            if reduce_str[i] == 0
+                dim_idx = tmp ÷ dst_str[i]
+                input_base_idx += dim_idx * src_str[i]
+            end
+            tmp = tmp % dst_str[i]
+        end
 
-    # Pre-reduce in strides of N across the reduction space
-    partial = neutral
-    i = ithread + 0x1
-    while i <= reduce_size
-        Ireduce = Rreduce[i]
-        J = max(Iother, Ireduce)
-        partial = op(partial, f(src[J]))
-        i += N
+        # Each thread reduces a strided slice of the reduce space
+        partial = neutral
+        j = ithread
+        while j < reduce_size
+            reduce_offset = typeof(ithread)(0)
+            tmp2 = j
+            KernelAbstractions.Extras.@unroll for i in ndim:-1i16:1i16
+                if reduce_str[i] > 0
+                    s = reduce_str[i] ÷ src_str[1]
+                    reduce_offset += (tmp2 ÷ s) * src_str[i]
+                    tmp2 = tmp2 % s
+                end
+            end
+            partial = op(partial, f(src[input_base_idx + reduce_offset + 0x1]))
+            j += N
+        end
+
+        sdata[ithread + 0x1] = partial
+        @synchronize()
+
+        @inline reduce_group!(@context, op, sdata, N, ithread)
+
+        if ithread == 0x0
+            dst[iblock + 0x1] = op(init, sdata[0x1])
+        end
+    end
+end
+
+
+# GPU kernel: multi-group reduction — multiple blocks per output element
+# Writes partial results to a (dst_sizes..., reduce_groups) array
+@kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_block_multigroup!(
+    @Const(src), partial,
+    f, op, neutral,
+    src_str, dst_str, reduce_str, partial_str,
+    output_size, reduce_size, reduce_groups, ndim,
+)
+    @uniform N = @groupsize()[1]
+    sdata = @localmem eltype(partial) (N,)
+
+    iblock  = @index(Group, Linear) - 0x1
+    ithread = @index(Local, Linear) - 0x1
+
+    # iblock encodes both which output element and which reduce group
+    iout   = iblock % output_size          # which output element
+    igroup = iblock ÷ output_size          # which reduce group
+
+    # Compute base index in src for this output element
+    input_base_idx = typeof(ithread)(0)
+    tmp = iout
+    KernelAbstractions.Extras.@unroll for i in ndim:-1i16:1i16
+        if reduce_str[i] == 0
+            dim_idx = tmp ÷ dst_str[i]
+            input_base_idx += dim_idx * src_str[i]
+        end
+        tmp = tmp % dst_str[i]
     end
 
-    # Store partial result in shared memory and reduce within block
-    sdata[ithread + 0x1] = partial
+    # Each group handles a chunk of the reduce space
+    chunk_start = igroup * N + ithread    # starting position in reduce space
+    chunk_stride = N * reduce_groups      # stride across groups
+
+    acc = neutral
+    j = chunk_start
+    while j < reduce_size
+        reduce_offset = typeof(ithread)(0)
+        tmp2 = j
+        KernelAbstractions.Extras.@unroll for i in ndim:-1i16:1i16
+            if reduce_str[i] > 0
+                s = reduce_str[i] ÷ src_str[1]
+                reduce_offset += (tmp2 ÷ s) * src_str[i]
+                tmp2 = tmp2 % s
+            end
+        end
+        acc = op(acc, f(src[input_base_idx + reduce_offset + 0x1]))
+        j += chunk_stride
+    end
+
+    sdata[ithread + 0x1] = acc
     @synchronize()
 
     @inline reduce_group!(@context, op, sdata, N, ithread)
 
     if ithread == 0x0
-        dst[Iother] = op(init, sdata[0x1])
+        # Write to partial[(iout linear), igroup+1]
+        partial_idx = iout + igroup * output_size
+        partial[partial_idx + 0x1] = sdata[0x1]
     end
 end

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -15,7 +15,7 @@
 
 # Number of blocks the by_block / multigroup paths aim to launch, so a reduction with
 # few output elements can still fill the GPU. A heuristic GPU-occupancy target.
-const TARGET_BLOCKS = 1024
+const TARGET_BLOCKS = 256
 
 # Below this many output elements, splitting a single output's reduction across multiple
 # blocks (multigroup) is preferred over grid-striding by_block, because grid-stride with

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -158,6 +158,7 @@ function mapreduce_nd(
     end
 
     src_strides = _mapreduce_strides(src)
+    _mapreduce_check_dense_strides(src, src_strides)
     reduce_segs, outer_segs = _canonicalize_dims(src_sizes, src_strides, dims_valid)
 
     outer_strides  = Tuple(str for (str, _) in outer_segs)
@@ -322,6 +323,26 @@ function _mapreduce_strides(src::Base.Broadcast.Broadcasted)
         s
     end
 end
+
+function _mapreduce_dense_strides(sizes::Tuple)
+    stride = 1
+    return ntuple(length(sizes)) do i
+        s = stride
+        stride *= sizes[i]
+        s
+    end
+end
+
+function _mapreduce_check_dense_strides(src::AbstractArray, src_strides)
+    dense_strides = _mapreduce_dense_strides(size(src))
+    src_strides == dense_strides && return nothing
+    throw(ArgumentError(
+        "GPU mapreduce with dims currently requires dense column-major source arrays; " *
+        "got strides $(src_strides), expected $(dense_strides)",
+    ))
+end
+
+_mapreduce_check_dense_strides(src::Base.Broadcast.Broadcasted, src_strides) = nothing
 
 
 # Smallest power-of-two >= n, capped at 256 (the original fixed block size) and

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -190,8 +190,27 @@ function mapreduce_nd(
         length(reduce_sizes) == 1 && reduce_sizes[1] != 0
 
     use_by_block = use_by_block_for_coalescing || use_by_block_for_low_occupancy
+    use_tiled_strided =
+        dst_size == reduce_size && reduce_size >= block_size &&
+        length(outer_sizes) == 1 && outer_strides == (1,) &&
+        length(reduce_sizes) == 1 && reduce_strides[1] > 1 &&
+        block_size % 8 == 0 && ispow2(block_size ÷ 8)
 
-    if dst_size >= reduce_size && !use_by_block
+    if use_tiled_strided
+        # Square-like row reductions with contiguous outputs and strided input
+        # reads, e.g. size=(1024,1024), dims=2. Several outputs share a block:
+        # small lane groups reduce one output each, preserving more cross-output
+        # memory coalescing than by_block while launching many more blocks than
+        # by_thread.
+        rows_per_block = 8
+        blocks = cld(dst_size, rows_per_block)
+        kernel! = _mapreduce_nd_by_thread_tiled_strided!(backend, block_size)
+        kernel!(
+            src, dst, f, op, init, neutral,
+            reduce_strides[1], dst_size, reduce_size, Val(rows_per_block),
+            ndrange=(block_size * blocks,),
+        )
+    elseif dst_size >= reduce_size && !use_by_block
         # Many outputs, small reduction: one thread per output reduces sequentially
         blocks = cld(dst_size, block_size)
         kernel! = _mapreduce_nd_by_thread!(backend, block_size)
@@ -375,6 +394,53 @@ end
 @inline _val(::Val{x}) where {x} = x
 @inline _udiv_const(x::Integer, ::Val{y}) where {y} = Int(Core.Intrinsics.udiv_int(UInt(x), UInt(y)))
 @inline _urem_const(x::Integer, ::Val{y}) where {y} = Int(Core.Intrinsics.urem_int(UInt(x), UInt(y)))
+
+@kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_thread_tiled_strided!(
+    @Const(src), dst,
+    f, op, init, neutral,
+    reduce_stride,
+    output_size, reduce_size,
+    rows_val,
+)
+    @uniform N = @groupsize()[1]
+    @uniform rows = _val(rows_val)
+    @uniform reduce_threads = N ÷ rows
+    sdata = @localmem eltype(dst) (N,)
+
+    iblock  = @index(Group, Linear) - 0x1
+    ithread = @index(Local, Linear) - 0x1
+
+    row  = _urem_const(ithread, rows_val)
+    lane = _udiv_const(ithread, rows_val)
+    iout = iblock * rows + row
+
+    acc = neutral
+    if iout < output_size
+        j = lane
+        while j < reduce_size
+            acc = op(acc, f(src[iout + j * reduce_stride + 0x1]))
+            j += reduce_threads
+        end
+    end
+
+    sdata[ithread + 0x1] = acc
+    @synchronize()
+
+    step = reduce_threads ÷ 2
+    while step >= 1
+        if lane < step
+            dst_lane = row + lane * rows
+            src_lane = row + (lane + step) * rows
+            sdata[dst_lane + 0x1] = op(sdata[dst_lane + 0x1], sdata[src_lane + 0x1])
+        end
+        @synchronize()
+        step ÷= 2
+    end
+
+    if lane == 0x0 && iout < output_size
+        dst[iout + 0x1] = op(init, sdata[row + 0x1])
+    end
+end
 
 # GPU kernel: by_thread — one thread per output element, reducing sequentially.
 # Used when there are more output elements than elements in the reduced dimension(s),

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -62,7 +62,7 @@ end
 function mapreduce_nd(
     f, op, src::MapReduceSource, backend::Backend;
     init,
-    neutral=neutral_element(op, _mapreduce_eltype(src)),
+    neutral=neutral_element(op, typeof(init)),
     dims::Union{Int, Tuple{Vararg{Int}}},
 
     # CPU settings

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -231,7 +231,7 @@ function mapreduce_nd(
             kernel!(
                 src, partial, f, op, neutral,
                 outer_strides, outer_sizes, reduce_strides, reduce_sizes,
-                dst_size, reduce_size, reduce_groups,
+                Val(dst_size), reduce_size, reduce_groups,
                 ndrange=(block_size * dst_size * reduce_groups,),
             )
 
@@ -358,6 +358,10 @@ end
     off
 end
 
+@inline _val(::Val{x}) where {x} = x
+@inline _udiv_const(x::Integer, ::Val{y}) where {y} = Int(Core.Intrinsics.udiv_int(UInt(x), UInt(y)))
+@inline _urem_const(x::Integer, ::Val{y}) where {y} = Int(Core.Intrinsics.urem_int(UInt(x), UInt(y)))
+
 # GPU kernel: by_thread — one thread per output element, reducing sequentially.
 # Used when there are more output elements than elements in the reduced dimension(s),
 # e.g. reduce(+, rand(3, 1000), dims=1) — only 3 elements to reduce per output.
@@ -449,16 +453,17 @@ end
     f, op, neutral,
     outer_strides, outer_sizes,
     reduce_strides, reduce_sizes,
-    output_size, reduce_size, reduce_groups,
+    output_size_val, reduce_size, reduce_groups,
 )
     @uniform N = @groupsize()[1]
+    @uniform output_size = _val(output_size_val)
     sdata = @localmem eltype(partial) (N,)
 
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
 
-    iout   = iblock % output_size
-    igroup = iblock ÷ output_size
+    iout   = _urem_const(iblock, output_size_val)
+    igroup = _udiv_const(iblock, output_size_val)
 
     input_base = _outer_decode(iout, outer_strides, outer_sizes)
 

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -89,6 +89,7 @@ function mapreduce_nd(
     temp::Union{Nothing, AbstractArray},
 )
     @argcheck 1 <= block_size <= 1024
+    @argcheck ispow2(block_size)
 
     dims_all = dims isa Int ? (dims,) : dims
 

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -6,6 +6,11 @@
 # 4. Multi-group reduction for large reduce spaces
 # 5. Input staging (K elements per thread before shared memory)
 
+# Number of first-pass blocks the multi-group reduction aims to launch, so a reduction with
+# very few output elements can still fill the GPU. A heuristic GPU-occupancy target; the
+# multi-group path is never used unless it launches at least as many blocks as by_block would.
+const TARGET_BLOCKS = 256
+
 # Host-side canonicalization
 
 function _canonicalize_dims(src_sizes, src_strides, dims_valid)
@@ -149,43 +154,18 @@ function mapreduce_nd(
         reduce_sizes_tup   = Tuple(s   for (_, s)   in reduce_segs)
         reduce_strides_tup = Tuple(str for (str, _) in reduce_segs)
 
-        reduce_size   = len
-        # Multi-group heuristic:
-        # - Always use if reduce_size is very large (> 16 * block_size)
-        # - Skip if dst_size is tiny AND reduce_size is moderate (overhead dominates)
-        raw_groups = (reduce_size + block_size - 1) ÷ block_size
-        reduce_groups = if raw_groups <= 1
-            1
-        elseif dst_size >= block_size
-            raw_groups  # large output: always multi-group
-        elseif reduce_size > 16 * block_size
-            raw_groups  # large reduction: need multi-group regardless
-        else
-            1           # small output + moderate reduction: single-group wins
+        reduce_size = len
+
+        # One block per output (by_block) launches `dst_size` blocks. When there are too few
+        # outputs to fill the GPU *and* the reduction is large, split each output's reduction
+        # across `reduce_groups` blocks and combine the partials in a cheap second pass. Capping
+        # at `block_size` keeps that second pass to a single block per output.
+        reduce_groups = 1
+        if dst_size < reduce_size && dst_size < TARGET_BLOCKS
+            reduce_groups = min(cld(reduce_size, block_size), block_size, cld(TARGET_BLOCKS, dst_size))
         end
 
-        if reduce_groups == 1
-            if dst_size >= reduce_size
-                blocks = (dst_size + block_size - 1) ÷ block_size
-                kernel! = _mapreduce_nd_by_thread!(backend, block_size)
-                kernel!(
-                    src, dst, f, op, init,
-                    outer_strides_tup, outer_sizes_tup,
-                    reduce_strides_tup, reduce_sizes_tup,
-                    dst_size, reduce_size,
-                    ndrange=(block_size * blocks,),
-                )
-            else
-                kernel! = _mapreduce_nd_by_block!(backend, block_size)
-                kernel!(
-                    src, dst, f, op, init, neutral,
-                    outer_strides_tup, outer_sizes_tup,
-                    reduce_strides_tup, reduce_sizes_tup,
-                    dst_size, reduce_size,
-                    ndrange=(block_size * dst_size,),
-                )
-            end
-        else
+        if reduce_groups > 1
             partial = KernelAbstractions.allocate(backend, typeof(init), (dst_size, reduce_groups))
 
             kernel! = _mapreduce_nd_multigroup!(backend, block_size)
@@ -197,28 +177,32 @@ function mapreduce_nd(
                 ndrange=(block_size * dst_size * reduce_groups,),
             )
 
-            # Second pass: reduce partial (dst_size × reduce_groups) → dst
-            if reduce_groups <= block_size
-                # Small enough: one block handles it sequentially — low overhead
-                kernel2! = _mapreduce_partial_to_dst!(backend, block_size)
-                kernel2!(
-                    partial, dst, op, init, neutral,
-                    dst_size, reduce_groups,
-                    ndrange=(block_size * dst_size,),
-                )
-            else
-                # Large: recurse with proper block reduction
-                dst_2d = reshape(dst, (dst_size, 1))
-                mapreduce_nd(
-                    identity, op, partial, backend;
-                    init,
-                    neutral,
-                    dims=2,
-                    max_tasks, min_elems, prefer_threads,
-                    block_size,
-                    temp=dst_2d,
-                )
-            end
+            # Second pass: reduce partial (dst_size × reduce_groups) → dst, one block per output
+            kernel2! = _mapreduce_partial_to_dst!(backend, block_size)
+            kernel2!(
+                partial, dst, op, init, neutral,
+                dst_size, reduce_groups,
+                ndrange=(block_size * dst_size,),
+            )
+        elseif dst_size >= reduce_size
+            blocks = cld(dst_size, block_size)
+            kernel! = _mapreduce_nd_by_thread!(backend, block_size)
+            kernel!(
+                src, dst, f, op, init,
+                outer_strides_tup, outer_sizes_tup,
+                reduce_strides_tup, reduce_sizes_tup,
+                dst_size, reduce_size,
+                ndrange=(block_size * blocks,),
+            )
+        else
+            kernel! = _mapreduce_nd_by_block!(backend, block_size)
+            kernel!(
+                src, dst, f, op, init, neutral,
+                outer_strides_tup, outer_sizes_tup,
+                reduce_strides_tup, reduce_sizes_tup,
+                dst_size, reduce_size,
+                ndrange=(block_size * dst_size,),
+            )
         end
     end
 

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -524,10 +524,10 @@ end
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
 
-    # rows is a compile-time constant, so unsigned div/rem lowers to a constant
-    # divisor (shift/and for the power-of-two rows) with no DivideError checks.
-    row  = unsigned(ithread) % unsigned(rows)
-    lane = unsigned(ithread) ÷ unsigned(rows)
+    # Int(...) keeps the index decode signed; a bare `unsigned ÷ unsigned` result feeds
+    # the signed index math and adds an Int-conversion throw guard NVPTX keeps (CUDA ~20%).
+    row  = Int(unsigned(ithread) % unsigned(rows))
+    lane = Int(unsigned(ithread) ÷ unsigned(rows))
     iout = iblock * rows + row
 
     acc = neutral
@@ -665,11 +665,9 @@ end
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
 
-    # output_size is a compile-time constant (Val), so unsigned div/rem keeps the
-    # constant divisor (magic-multiply) with no DivideError checks. Signed div/rem
-    # would route the divisor through air.abs/abs, defeating the constant folding.
-    iout   = unsigned(iblock) % unsigned(output_size)
-    igroup = unsigned(iblock) ÷ unsigned(output_size)
+    # Int(...) keeps the index decode signed (see tiled kernel): avoids a CUDA throw guard.
+    iout   = Int(unsigned(iblock) % unsigned(output_size))
+    igroup = Int(unsigned(iblock) ÷ unsigned(output_size))
 
     input_base = base_offset + _outer_decode(iout, outer_strides, outer_sizes)
 

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -10,13 +10,22 @@
 #      `dims=(1,3)`) fall back to a per-element multi-dimensional decode.
 #   3. Three work decompositions, chosen by the relative sizes of the output and the reduction:
 #        - by_thread:  one thread per output (many outputs, small reduction)
-#        - by_block:   one block per output  (few outputs, large reduction)
-#        - multigroup: several blocks per output, two-pass (very few outputs, huge reduction)
+#        - by_block:   one block per output, grid-stride over outputs (few outputs, large reduction)
+#        - multigroup: several blocks per output, two-pass (dst_size==1 or very small dst_size)
 
-# Number of first-pass blocks the multi-group reduction aims to launch, so a reduction with
-# very few output elements can still fill the GPU. A heuristic GPU-occupancy target; the
-# multi-group path is never used unless it launches at least as many blocks as by_block would.
-const TARGET_BLOCKS = 256
+# Number of blocks the by_block / multigroup paths aim to launch, so a reduction with
+# few output elements can still fill the GPU. A heuristic GPU-occupancy target.
+const TARGET_BLOCKS = 1024
+
+# Below this many output elements, splitting a single output's reduction across multiple
+# blocks (multigroup) is preferred over grid-striding by_block, because grid-stride with
+# too few blocks cannot fill the GPU on its own. At or above this, by_block grid-strides.
+const GS_DST_CUTOFF = 32
+
+# Minimum reduction-loop iterations per thread in the multigroup first pass.
+# Caps reduce_groups so splitting a reduction doesn't shrink per-thread work
+# below the point where launch/scheduling overhead dominates actual work.
+const MIN_ITEMS_PER_THREAD = 8
 
 
 # Host-side canonicalization: split the dimensions into reduced and kept ("outer") segments,
@@ -144,34 +153,37 @@ function mapreduce_nd(
     reduce_sizes   = Tuple(s   for (_, s)   in reduce_segs)
     reduce_size    = len
 
-    # One block per output (by_block) launches `dst_size` blocks. When there are too few
-    # outputs to fill the GPU *and* the reduction is large, split each output's reduction
-    # across `reduce_groups` blocks and combine the partials in a cheap second pass. Capping
-    # at `block_size` keeps that second pass to a single block per output.
-    reduce_groups = 1
-    if dst_size < reduce_size && dst_size < TARGET_BLOCKS
-        reduce_groups = min(cld(reduce_size, block_size), block_size, cld(TARGET_BLOCKS, dst_size))
-    end
+    # ─────────────────────────────────────────────────────────────────────────
+    # Dispatch decision (see header comment for the three paths):
+    #
+    #   - dst_size >= reduce_size                         -> by_thread
+    #   - dst_size == 1, or dst_size < GS_DST_CUTOFF
+    #     (and dst_size < reduce_size)                    -> multigroup (split one
+    #                                                         reduction across blocks,
+    #                                                         needs a 2nd-pass combine)
+    #   - otherwise (GS_DST_CUTOFF <= dst_size < reduce_size)
+    #                                                      -> by_block, grid-striding
+    #                                                         over outputs, single pass
+    #
+    # Rationale: grid-striding by_block launches `min(dst_size, TARGET_BLOCKS)` blocks;
+    # for very small dst_size (e.g. 5 or 9) that under-fills an 84-SM GPU, so splitting
+    # the (large) reduction itself across many blocks via multigroup is still better.
+    # For dst_size==1 there is nothing to grid-stride over, so multigroup is the only
+    # option regardless of GS_DST_CUTOFF.
+    # ─────────────────────────────────────────────────────────────────────────
 
-    if reduce_groups > 1
-        partial = KernelAbstractions.allocate(backend, typeof(init), (dst_size, reduce_groups))
+    # Coalescing override: when the reduced dimension is the fastest-varying one
+    # (reduce_strides==(1,)) and reduce_size is large enough to amortize a
+    # shared-memory tree-reduce (>=32, one warp), by_thread's per-thread strided
+    # access (stride==reduce_size across threads) is badly uncoalesced, while
+    # by_block lets consecutive threads read consecutive elements. Below 32,
+    # by_block's sync overhead isn't worth it for so few elements.
+    use_by_block_for_coalescing =
+        dst_size >= reduce_size && reduce_size >= block_size &&
+        length(reduce_sizes) == 1 && reduce_sizes[1] != 0 &&
+        reduce_strides == (1,)
 
-        kernel! = _mapreduce_nd_multigroup!(backend, block_size)
-        kernel!(
-            src, partial, f, op, neutral,
-            outer_strides, outer_sizes, reduce_strides, reduce_sizes,
-            dst_size, reduce_size, reduce_groups,
-            ndrange=(block_size * dst_size * reduce_groups,),
-        )
-
-        # Second pass: reduce partial (dst_size × reduce_groups) → dst, one block per output
-        kernel2! = _mapreduce_partial_to_dst!(backend, block_size)
-        kernel2!(
-            partial, dst, op, init, neutral,
-            dst_size, reduce_groups,
-            ndrange=(block_size * dst_size,),
-        )
-    elseif dst_size >= reduce_size
+    if dst_size >= reduce_size && !use_by_block_for_coalescing
         # Many outputs, small reduction: one thread per output reduces sequentially
         blocks = cld(dst_size, block_size)
         kernel! = _mapreduce_nd_by_thread!(backend, block_size)
@@ -181,18 +193,86 @@ function mapreduce_nd(
             dst_size, reduce_size,
             ndrange=(block_size * blocks,),
         )
-    else
-        # Few outputs, large reduction: one block of threads cooperatively reduces each output
+    elseif use_by_block_for_coalescing
+        # Grid-stride by_block: consecutive threads read consecutive (stride-1)
+        # elements of the reduced dimension -> coalesced.
+        launch_blocks = min(dst_size, TARGET_BLOCKS)
         kernel! = _mapreduce_nd_by_block!(backend, block_size)
         kernel!(
             src, dst, f, op, init, neutral,
             outer_strides, outer_sizes, reduce_strides, reduce_sizes,
-            dst_size, reduce_size,
-            ndrange=(block_size * dst_size,),
+            dst_size, reduce_size, launch_blocks,
+            ndrange=(block_size * launch_blocks,),
+        )
+    elseif dst_size == 1 || dst_size < GS_DST_CUTOFF
+        # Very few outputs, large reduction: split each output's reduction across
+        # `reduce_groups` blocks (multigroup), combine partials in a second pass.
+        reduce_groups = min(
+            cld(reduce_size, block_size),
+            block_size,
+            cld(TARGET_BLOCKS, dst_size),
+            cld(reduce_size, block_size * MIN_ITEMS_PER_THREAD),
+        )
+        reduce_groups = max(reduce_groups, 1)
+
+        if reduce_groups > 1
+            partial = KernelAbstractions.allocate(backend, typeof(init), (dst_size, reduce_groups))
+
+            kernel! = _mapreduce_nd_multigroup!(backend, block_size)
+            kernel!(
+                src, partial, f, op, neutral,
+                outer_strides, outer_sizes, reduce_strides, reduce_sizes,
+                dst_size, reduce_size, reduce_groups,
+                ndrange=(block_size * dst_size * reduce_groups,),
+            )
+
+            # Second pass: reduce partial (dst_size × reduce_groups) → dst, one block
+            # per output. reduce_groups is small (<=block_size by construction), so use
+            # a small block size for this pass to avoid an oversubscribed tree-reduce.
+            pass2_block_size = _pass2_block_size(reduce_groups)
+            kernel2! = _mapreduce_partial_to_dst!(backend, pass2_block_size)
+            kernel2!(
+                partial, dst, op, init, neutral,
+                dst_size, reduce_groups,
+                ndrange=(pass2_block_size * dst_size,),
+            )
+        else
+            # reduce_groups collapsed to 1 (e.g. reduce_size <= block_size): just do a
+            # single-block-per-output reduction directly, no partial array needed.
+            kernel! = _mapreduce_nd_by_block!(backend, block_size)
+            kernel!(
+                src, dst, f, op, init, neutral,
+                outer_strides, outer_sizes, reduce_strides, reduce_sizes,
+                dst_size, reduce_size, dst_size,
+                ndrange=(block_size * dst_size,),
+            )
+        end
+    else
+        # GS_DST_CUTOFF <= dst_size < reduce_size: grid-stride over outputs, one pass.
+        # Cap launched blocks at TARGET_BLOCKS; each block handles
+        # ceil(dst_size / launch_blocks) outputs sequentially.
+        launch_blocks = min(dst_size, TARGET_BLOCKS)
+        kernel! = _mapreduce_nd_by_block!(backend, block_size)
+        kernel!(
+            src, dst, f, op, init, neutral,
+            outer_strides, outer_sizes, reduce_strides, reduce_sizes,
+            dst_size, reduce_size, launch_blocks,
+            ndrange=(block_size * launch_blocks,),
         )
     end
 
     return dst
+end
+
+
+# Smallest power-of-two >= n, capped at 256 (the original fixed block size) and
+# floored at 32 (one warp) — used for the multigroup second pass, which only ever
+# combines `reduce_groups` values (reduce_groups <= block_size by construction).
+@inline function _pass2_block_size(n::Int)
+    n <= 32  && return 32
+    n <= 64  && return 64
+    n <= 128 && return 128
+    return 256
 end
 
 
@@ -292,27 +372,32 @@ end
     end
 end
 
-# GPU kernel: by_block — one block of threads cooperatively reduces each output element.
-# Used when there are more elements in the reduced dimension(s) than output elements,
-# e.g. reduce(+, rand(3, 1000), dims=2) — only 3 output elements.
+# GPU kernel: by_block — each block reduces one output element, then grid-strides to
+# the next output (iout += num_blocks) until all outputs are covered. When
+# num_blocks >= output_size, each block handles at most one output (the original,
+# non-striding behavior) at zero extra cost — the while loop runs once.
+#
+# Used for GS_DST_CUTOFF <= dst_size < reduce_size (grid-stride, num_blocks ==
+# min(dst_size, TARGET_BLOCKS) < dst_size in general), and also for the
+# reduce_groups==1 fallback inside the multigroup branch (num_blocks == dst_size,
+# so the loop runs exactly once per block — identical to the pre-grid-stride kernel).
 
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_block!(
     @Const(src), dst,
     f, op, init, neutral,
     outer_strides, outer_sizes,
     reduce_strides, reduce_sizes,
-    output_size, reduce_size,
+    output_size, reduce_size, num_blocks,
 )
     @uniform N = @groupsize()[1]
     sdata = @localmem eltype(dst) (N,)
 
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
+    iout = iblock
+    while true
+        input_base = _outer_decode(iout, outer_strides, outer_sizes)
 
-    if iblock < output_size
-        input_base = _outer_decode(iblock, outer_strides, outer_sizes)
-
-        # Pre-reduce in strides of N (consecutive threads read consecutive elements)
         acc = neutral
         j   = ithread
         while j < reduce_size
@@ -327,10 +412,16 @@ end
         @inline reduce_group!(@context, op, sdata, N, ithread)
 
         if ithread == 0x0
-            dst[iblock + 0x1] = op(init, sdata[0x1])
+            dst[iout + 0x1] = op(init, sdata[0x1])
         end
+
+        next_iout = iout + num_blocks
+        next_iout >= output_size && break
+
+        @synchronize()
+        iout = next_iout
     end
-end
+   end
 
 # GPU kernel: multi-group first pass — several blocks per output element. Block `iblock`
 # handles output `iout` and group `igroup`, reducing its interleaved slice of the reduction
@@ -373,7 +464,9 @@ end
 end
 
 # GPU kernel: multi-group second pass — one block per output reduces over the `reduce_groups`
-# partials and folds in `init`.
+# partials and folds in `init`. Launched with a block size sized to `reduce_groups`
+# (see _pass2_block_size), avoiding an oversubscribed tree-reduce when reduce_groups
+# is much smaller than 256.
 
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_partial_to_dst!(
     @Const(partial), dst,
@@ -404,3 +497,4 @@ end
         end
     end
 end
+

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -429,27 +429,24 @@ end
     off
 end
 
-@inline _val(::Val{x}) where {x} = x
-@inline _udiv_const(x::Integer, ::Val{y}) where {y} = Int(Core.Intrinsics.udiv_int(UInt(x), UInt(y)))
-@inline _urem_const(x::Integer, ::Val{y}) where {y} = Int(Core.Intrinsics.urem_int(UInt(x), UInt(y)))
-
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_thread_tiled_strided!(
     @Const(src), dst,
     f, op, init, neutral,
     reduce_stride,
     output_size, reduce_size,
-    rows_val,
-)
+    ::Val{rows},
+) where {rows}
     @uniform N = @groupsize()[1]
-    @uniform rows = _val(rows_val)
     @uniform reduce_threads = N ÷ rows
     sdata = @localmem eltype(dst) (N,)
 
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
 
-    row  = _urem_const(ithread, rows_val)
-    lane = _udiv_const(ithread, rows_val)
+    # rows is a compile-time constant, so unsigned div/rem lowers to a constant
+    # divisor (shift/and for the power-of-two rows) with no DivideError checks.
+    row  = unsigned(ithread) % unsigned(rows)
+    lane = unsigned(ithread) ÷ unsigned(rows)
     iout = iblock * rows + row
 
     acc = neutral
@@ -571,17 +568,19 @@ end
     f, op, neutral,
     outer_strides, outer_sizes,
     reduce_strides, reduce_sizes,
-    output_size_val, reduce_size, reduce_groups,
-)
+    ::Val{output_size}, reduce_size, reduce_groups,
+) where {output_size}
     @uniform N = @groupsize()[1]
-    @uniform output_size = _val(output_size_val)
     sdata = @localmem eltype(partial) (N,)
 
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
 
-    iout   = _urem_const(iblock, output_size_val)
-    igroup = _udiv_const(iblock, output_size_val)
+    # output_size is a compile-time constant (Val), so unsigned div/rem keeps the
+    # constant divisor (magic-multiply) with no DivideError checks. Signed div/rem
+    # would route the divisor through air.abs/abs, defeating the constant folding.
+    iout   = unsigned(iblock) % unsigned(output_size)
+    igroup = unsigned(iblock) ÷ unsigned(output_size)
 
     input_base = _outer_decode(iout, outer_strides, outer_sizes)
 

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -252,6 +252,7 @@ end
 
 @inline function _outer_decode(tid, outer_strides, outer_sizes)
     isempty(outer_sizes) && return 0
+    length(outer_sizes) == 1 && return tid * outer_strides[1]
     base = 0
     tmp  = tid
     @inbounds for i in 1:length(outer_sizes)
@@ -265,6 +266,9 @@ end
 
 @inline function _reduce_offset(j, reduce_strides, reduce_sizes)
     isempty(reduce_sizes) && return 0
+    # Single segment (the common case after canonicalization): j < reduce_size, so the
+    # decode is just j * stride — no per-element division.
+    length(reduce_sizes) == 1 && return j * reduce_strides[1]
     off = 0
     tmp = j
     @inbounds for i in 1:length(reduce_sizes)

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -59,6 +59,11 @@ function mapreduce_nd(
         throw(ArgumentError("region dimension(s) must be ≥ 1, got $dims"))
     end
 
+    # Duplicate dims check: Base errors on dims=(2,2)
+    if length(dims_all) != length(Base.unique(dims_all))
+        throw(ArgumentError("region dimension(s) must be unique, got $dims"))
+    end
+
     src_sizes   = size(src)
     src_strides = strides(src)
     ndim        = length(src_sizes)
@@ -197,7 +202,7 @@ function mapreduce_nd(
                 # Small enough: one block handles it sequentially — low overhead
                 kernel2! = _mapreduce_partial_to_dst!(backend, block_size)
                 kernel2!(
-                    partial, dst, op, init,
+                    partial, dst, op, init, neutral,
                     dst_size, reduce_groups,
                     ndrange=(block_size * dst_size,),
                 )
@@ -387,7 +392,7 @@ end
 
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_partial_to_dst!(
     @Const(partial), dst,
-    op, init,
+    op, init, neutral,
     output_size, reduce_groups,
 )
     # One block per output element — block reduces over reduce_groups
@@ -399,7 +404,7 @@ end
 
     if iblock < output_size
         # Each thread strides over reduce_groups
-        acc = eltype(dst)(0)  # neutral for this pass — init applied at end
+        acc = neutral
         g = ithread
         while g < reduce_groups
             acc = op(acc, partial[iblock + g * output_size + 0x1])

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -165,8 +165,8 @@ function mapreduce_nd(
                 kernel! = _mapreduce_nd_by_thread!(backend, block_size)
                 kernel!(
                     src, dst, f, op, init,
-                    outer_strides_tup, Val(outer_sizes_tup),
-                    reduce_strides_tup, Val(reduce_sizes_tup),
+                    outer_strides_tup, outer_sizes_tup,
+                    reduce_strides_tup, reduce_sizes_tup,
                     dst_size, reduce_size,
                     ndrange=(block_size * blocks,),
                 )
@@ -174,8 +174,8 @@ function mapreduce_nd(
                 kernel! = _mapreduce_nd_by_block!(backend, block_size)
                 kernel!(
                     src, dst, f, op, init, neutral,
-                    outer_strides_tup, Val(outer_sizes_tup),
-                    reduce_strides_tup, Val(reduce_sizes_tup),
+                    outer_strides_tup, outer_sizes_tup,
+                    reduce_strides_tup, reduce_sizes_tup,
                     dst_size, reduce_size,
                     ndrange=(block_size * dst_size,),
                 )
@@ -186,8 +186,8 @@ function mapreduce_nd(
             kernel! = _mapreduce_nd_multigroup!(backend, block_size)
             kernel!(
                 src, partial, f, op, neutral,
-                outer_strides_tup, Val(outer_sizes_tup),
-                reduce_strides_tup, Val(reduce_sizes_tup),
+                outer_strides_tup, outer_sizes_tup,
+                reduce_strides_tup, reduce_sizes_tup,
                 dst_size, reduce_size, reduce_groups,
                 ndrange=(block_size * dst_size * reduce_groups,),
             )
@@ -245,10 +245,8 @@ end
 
 # Index helpers
 
-@inline function _outer_decode(tid, outer_strides, ::Val{outer_sizes}) where outer_sizes
-    # Walk dims from smallest stride to largest stride (column-major order)
-    # outer_segs are already in column-major order (dim 1 first, lowest stride first)
-    # So we walk 1..N: extract the low-order index first
+@inline function _outer_decode(tid, outer_strides, outer_sizes)
+    isempty(outer_sizes) && return 0
     base = 0
     tmp  = tid
     @inbounds for i in 1:length(outer_sizes)
@@ -260,8 +258,8 @@ end
     base
 end
 
-@inline function _reduce_offset(j, reduce_strides, ::Val{reduce_sizes}) where reduce_sizes
-    # Walk from smallest stride to largest (column-major)
+@inline function _reduce_offset(j, reduce_strides, reduce_sizes)
+    isempty(reduce_sizes) && return 0
     off = 0
     tmp = j
     @inbounds for i in 1:length(reduce_sizes)
@@ -278,21 +276,21 @@ end
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_thread!(
     @Const(src), dst,
     f, op, init,
-    outer_strides, ::Val{outer_sizes},
-    reduce_strides, ::Val{reduce_sizes},
+    outer_strides, outer_sizes,
+    reduce_strides, reduce_sizes,
     output_size, reduce_size,
-) where {outer_sizes, reduce_sizes}
+)
     N       = @groupsize()[1]
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
     tid     = ithread + iblock * N
 
     if tid < output_size
-        input_base = _outer_decode(tid, outer_strides, Val(outer_sizes))
+        input_base = _outer_decode(tid, outer_strides, outer_sizes)
 
         res = init
         for j in 0x0:reduce_size - 0x1
-            off = _reduce_offset(j, reduce_strides, Val(reduce_sizes))
+            off = _reduce_offset(j, reduce_strides, reduce_sizes)
             res = op(res, f(src[input_base + off + 0x1]))
         end
 
@@ -307,10 +305,10 @@ const _STAGING = 4
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_block!(
     @Const(src), dst,
     f, op, init, neutral,
-    outer_strides, ::Val{outer_sizes},
-    reduce_strides, ::Val{reduce_sizes},
+    outer_strides, outer_sizes,
+    reduce_strides, reduce_sizes,
     output_size, reduce_size,
-) where {outer_sizes, reduce_sizes}
+)
     @uniform N = @groupsize()[1]
     sdata = @localmem eltype(dst) (N,)
 
@@ -318,14 +316,14 @@ const _STAGING = 4
     ithread = @index(Local, Linear) - 0x1
 
     if iblock < output_size
-        input_base = _outer_decode(iblock, outer_strides, Val(outer_sizes))
+        input_base = _outer_decode(iblock, outer_strides, outer_sizes)
 
         acc = neutral
         j   = ithread
         while j < reduce_size
             KernelAbstractions.Extras.@unroll for k in 1:_STAGING
                 if j < reduce_size
-                    off = _reduce_offset(j, reduce_strides, Val(reduce_sizes))
+                    off = _reduce_offset(j, reduce_strides, reduce_sizes)
                     acc = op(acc, f(src[input_base + off + 0x1]))
                     j  += N
                 end
@@ -348,10 +346,10 @@ end
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_multigroup!(
     @Const(src), partial,
     f, op, neutral,
-    outer_strides, ::Val{outer_sizes},
-    reduce_strides, ::Val{reduce_sizes},
+    outer_strides, outer_sizes,
+    reduce_strides, reduce_sizes,
     output_size, reduce_size, reduce_groups,
-) where {outer_sizes, reduce_sizes}
+)
     @uniform N = @groupsize()[1]
     sdata = @localmem eltype(partial) (N,)
 
@@ -361,14 +359,14 @@ end
     iout   = iblock % output_size
     igroup = iblock ÷ output_size
 
-    input_base = _outer_decode(iout, outer_strides, Val(outer_sizes))
+    input_base = _outer_decode(iout, outer_strides, outer_sizes)
 
     acc = neutral
     j   = ithread + igroup * N
     while j < reduce_size
         KernelAbstractions.Extras.@unroll for k in 1:_STAGING
             if j < reduce_size
-                off = _reduce_offset(j, reduce_strides, Val(reduce_sizes))
+                off = _reduce_offset(j, reduce_strides, reduce_sizes)
                 acc = op(acc, f(src[input_base + off + 0x1]))
                 j  += N * reduce_groups
             end

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -1,18 +1,27 @@
-# Generalized N-dimensional mapreduce for GPU and CPU backends.
-
-# 1. Dimension canonicalization: collapse adjacent reducible dims into contiguous segments
-# 2. ND decode happens ONCE outside the inner loop using Val{sizes} (compile-time div → mulhi)
-# 3. Inner loop is pure multiply-add, zero div/mod — compiler can vectorize
-# 4. Multi-group reduction for large reduce spaces
-# 5. Input staging (K elements per thread before shared memory)
+# Generalized N-dimensional mapreduce for GPU and CPU backends, reducing one or more
+# dimensions (`dims::Int` or `dims::Tuple`) of `src` into `dst`.
+#
+# Design (see references: CUDA.jl / GPUArrays mapreducedim!, PyTorch Reduce.cuh, CUB):
+#   1. Canonicalize dims: collapse adjacent dimensions with matching strides into contiguous
+#      segments. A plain `dims=2` reduction, or any reduction over a contiguous block of dims
+#      (e.g. `dims=(1,2)`), collapses to a *single* reduce segment.
+#   2. The inner reduce loop must avoid per-element integer division. For a single segment the
+#      element offset is just `j * stride`; only genuinely non-contiguous dim sets (e.g.
+#      `dims=(1,3)`) fall back to a per-element multi-dimensional decode.
+#   3. Three work decompositions, chosen by the relative sizes of the output and the reduction:
+#        - by_thread:  one thread per output (many outputs, small reduction)
+#        - by_block:   one block per output  (few outputs, large reduction)
+#        - multigroup: several blocks per output, two-pass (very few outputs, huge reduction)
 
 # Number of first-pass blocks the multi-group reduction aims to launch, so a reduction with
 # very few output elements can still fill the GPU. A heuristic GPU-occupancy target; the
 # multi-group path is never used unless it launches at least as many blocks as by_block would.
 const TARGET_BLOCKS = 256
 
-# Host-side canonicalization
 
+# Host-side canonicalization: split the dimensions into reduced and kept ("outer") segments,
+# merging adjacent dimensions whose strides are contiguous. Returns two tuples of
+# (stride, size) segments.
 function _canonicalize_dims(src_sizes, src_strides, dims_valid)
     ndim = length(src_sizes)
     reduce_segs = Tuple{Int,Int}[]
@@ -75,145 +84,132 @@ function mapreduce_nd(
 
     dims_valid = Tuple(d for d in dims_all if d <= ndim)
 
+    # Degenerate cases begin; order of priority matters
+
+    # All reduced dims are beyond ndims: just map each element through f and add init, e.g.:
+    #   julia> x = rand(Float64, 3, 5);
+    #   julia> mapreduce(x -> -x, +, x, dims=3, init=Float32(0))     # 3×5 Matrix{Float32}
     if isempty(dims_valid)
-        if isnothing(temp)
-            dst = KernelAbstractions.allocate(backend, typeof(init), src_sizes)
-        else
-            @argcheck get_backend(temp) == backend
-            @argcheck size(temp) == src_sizes
-            @argcheck eltype(temp) == typeof(init)
-            dst = temp
-        end
+        dst = _alloc_or_temp(backend, temp, init, src_sizes)
         _mapreduce_nd_apply_init!(f, op, dst, src, backend; init, max_tasks, min_elems, block_size)
         return dst
     end
 
+    # The per-dimension sizes of the destination array; construct tuple without allocations
     dst_sizes = unrolled_map_index(src_sizes) do i
         i in dims_valid ? 1 : src_sizes[i]
     end
 
+    # If any kept dimension is zero, return empty array (reduced dims become 1), e.g.:
+    #   julia> x = rand(3, 0, 5);  reduce(+, x, dims=3)     # 3×0×1 Array{Float64, 3}
     for isize in eachindex(src_sizes)
         isize in dims_valid && continue
         if src_sizes[isize] == 0
-            if isnothing(temp)
-                dst = KernelAbstractions.allocate(backend, typeof(init), dst_sizes)
-            else
-                @argcheck size(temp) == dst_sizes
-                @argcheck eltype(temp) == typeof(init)
-                dst = temp
-            end
-            return dst
+            return _alloc_or_temp(backend, temp, init, dst_sizes)
         end
     end
 
     len = Base.prod(src_sizes[d] for d in dims_valid)
 
+    # If a reduced dimension is zero, return array filled with init, e.g.:
+    #   julia> x = rand(3, 0, 5);  mapreduce(+, x, dims=2)     # 3×1×5 of zeros
     if len == 0
-        if isnothing(temp)
-            dst = KernelAbstractions.allocate(backend, typeof(init), dst_sizes)
-        else
-            @argcheck get_backend(temp) == backend
-            @argcheck size(temp) == dst_sizes
-            @argcheck eltype(temp) == typeof(init)
-            dst = temp
-        end
+        dst = _alloc_or_temp(backend, temp, init, dst_sizes)
         fill!(dst, init)
         return dst
     end
 
+    # If the reduced extent is 1, just map each element through f (keep init's type)
     if len == 1
-        if isnothing(temp)
-            dst = KernelAbstractions.allocate(backend, typeof(init), src_sizes)
-        else
-            @argcheck get_backend(temp) == backend
-            @argcheck size(temp) == src_sizes
-            @argcheck eltype(temp) == typeof(init)
-            dst = temp
-        end
+        dst = _alloc_or_temp(backend, temp, init, src_sizes)
         _mapreduce_nd_apply_init!(f, op, dst, src, backend; init, max_tasks, min_elems, block_size)
         return dst
     end
 
-    if isnothing(temp)
-        dst = KernelAbstractions.allocate(backend, typeof(init), dst_sizes)
-    else
-        @argcheck get_backend(temp) == backend
-        @argcheck size(temp) == dst_sizes
-        @argcheck eltype(temp) == typeof(init)
-        dst = temp
-    end
+    # Degenerate cases end
+
+    dst = _alloc_or_temp(backend, temp, init, dst_sizes)
     dst_size = length(dst)
 
     if !use_gpu_algorithm(backend, prefer_threads)
-        _mapreduce_nd_cpu_sections!(f, op, dst, src; init, dims=dims_valid, max_tasks, min_elems)
+        _mapreduce_nd_cpu_sections!(f, op, dst, src; init, max_tasks, min_elems)
+        return dst
+    end
+
+    reduce_segs, outer_segs = _canonicalize_dims(src_sizes, src_strides, dims_valid)
+
+    outer_strides  = Tuple(str for (str, _) in outer_segs)
+    outer_sizes    = Tuple(s   for (_, s)   in outer_segs)
+    reduce_strides = Tuple(str for (str, _) in reduce_segs)
+    reduce_sizes   = Tuple(s   for (_, s)   in reduce_segs)
+    reduce_size    = len
+
+    # One block per output (by_block) launches `dst_size` blocks. When there are too few
+    # outputs to fill the GPU *and* the reduction is large, split each output's reduction
+    # across `reduce_groups` blocks and combine the partials in a cheap second pass. Capping
+    # at `block_size` keeps that second pass to a single block per output.
+    reduce_groups = 1
+    if dst_size < reduce_size && dst_size < TARGET_BLOCKS
+        reduce_groups = min(cld(reduce_size, block_size), block_size, cld(TARGET_BLOCKS, dst_size))
+    end
+
+    if reduce_groups > 1
+        partial = KernelAbstractions.allocate(backend, typeof(init), (dst_size, reduce_groups))
+
+        kernel! = _mapreduce_nd_multigroup!(backend, block_size)
+        kernel!(
+            src, partial, f, op, neutral,
+            outer_strides, outer_sizes, reduce_strides, reduce_sizes,
+            dst_size, reduce_size, reduce_groups,
+            ndrange=(block_size * dst_size * reduce_groups,),
+        )
+
+        # Second pass: reduce partial (dst_size × reduce_groups) → dst, one block per output
+        kernel2! = _mapreduce_partial_to_dst!(backend, block_size)
+        kernel2!(
+            partial, dst, op, init, neutral,
+            dst_size, reduce_groups,
+            ndrange=(block_size * dst_size,),
+        )
+    elseif dst_size >= reduce_size
+        # Many outputs, small reduction: one thread per output reduces sequentially
+        blocks = cld(dst_size, block_size)
+        kernel! = _mapreduce_nd_by_thread!(backend, block_size)
+        kernel!(
+            src, dst, f, op, init,
+            outer_strides, outer_sizes, reduce_strides, reduce_sizes,
+            dst_size, reduce_size,
+            ndrange=(block_size * blocks,),
+        )
     else
-        reduce_segs, outer_segs = _canonicalize_dims(src_sizes, src_strides, dims_valid)
-
-        outer_sizes_tup    = Tuple(s   for (_, s)   in outer_segs)
-        outer_strides_tup  = Tuple(str for (str, _) in outer_segs)
-        reduce_sizes_tup   = Tuple(s   for (_, s)   in reduce_segs)
-        reduce_strides_tup = Tuple(str for (str, _) in reduce_segs)
-
-        reduce_size = len
-
-        # One block per output (by_block) launches `dst_size` blocks. When there are too few
-        # outputs to fill the GPU *and* the reduction is large, split each output's reduction
-        # across `reduce_groups` blocks and combine the partials in a cheap second pass. Capping
-        # at `block_size` keeps that second pass to a single block per output.
-        reduce_groups = 1
-        if dst_size < reduce_size && dst_size < TARGET_BLOCKS
-            reduce_groups = min(cld(reduce_size, block_size), block_size, cld(TARGET_BLOCKS, dst_size))
-        end
-
-        if reduce_groups > 1
-            partial = KernelAbstractions.allocate(backend, typeof(init), (dst_size, reduce_groups))
-
-            kernel! = _mapreduce_nd_multigroup!(backend, block_size)
-            kernel!(
-                src, partial, f, op, neutral,
-                outer_strides_tup, outer_sizes_tup,
-                reduce_strides_tup, reduce_sizes_tup,
-                dst_size, reduce_size, reduce_groups,
-                ndrange=(block_size * dst_size * reduce_groups,),
-            )
-
-            # Second pass: reduce partial (dst_size × reduce_groups) → dst, one block per output
-            kernel2! = _mapreduce_partial_to_dst!(backend, block_size)
-            kernel2!(
-                partial, dst, op, init, neutral,
-                dst_size, reduce_groups,
-                ndrange=(block_size * dst_size,),
-            )
-        elseif dst_size >= reduce_size
-            blocks = cld(dst_size, block_size)
-            kernel! = _mapreduce_nd_by_thread!(backend, block_size)
-            kernel!(
-                src, dst, f, op, init,
-                outer_strides_tup, outer_sizes_tup,
-                reduce_strides_tup, reduce_sizes_tup,
-                dst_size, reduce_size,
-                ndrange=(block_size * blocks,),
-            )
-        else
-            kernel! = _mapreduce_nd_by_block!(backend, block_size)
-            kernel!(
-                src, dst, f, op, init, neutral,
-                outer_strides_tup, outer_sizes_tup,
-                reduce_strides_tup, reduce_sizes_tup,
-                dst_size, reduce_size,
-                ndrange=(block_size * dst_size,),
-            )
-        end
+        # Few outputs, large reduction: one block of threads cooperatively reduces each output
+        kernel! = _mapreduce_nd_by_block!(backend, block_size)
+        kernel!(
+            src, dst, f, op, init, neutral,
+            outer_strides, outer_sizes, reduce_strides, reduce_sizes,
+            dst_size, reduce_size,
+            ndrange=(block_size * dst_size,),
+        )
     end
 
     return dst
+end
+
+
+# Allocate a destination array, or validate and reuse a user-provided `temp`.
+function _alloc_or_temp(backend, temp, init, sizes)
+    isnothing(temp) && return KernelAbstractions.allocate(backend, typeof(init), sizes)
+    @argcheck get_backend(temp) == backend
+    @argcheck size(temp) == sizes
+    @argcheck eltype(temp) == typeof(init)
+    temp
 end
 
 # CPU path
 
 function _mapreduce_nd_cpu_sections!(
     f, op, dst, src;
-    init, dims, max_tasks, min_elems,
+    init, max_tasks, min_elems,
 )
     Rother  = CartesianIndices(dst)
     Rreduce = CartesianIndices(ifelse.(axes(src) .== axes(dst), Ref(Base.OneTo(1)), axes(src)))
@@ -232,7 +228,9 @@ function _mapreduce_nd_cpu_sections!(
     dst
 end
 
-# Index helpers
+# Index helpers. Both decode a linear index into a byte-offset by walking compile-time-sized
+# segment tuples. The single-segment case (the common one after canonicalization) needs no
+# division; multi-segment falls back to a per-element decode (rare: non-adjacent dim sets).
 
 @inline function _outer_decode(tid, outer_strides, outer_sizes)
     isempty(outer_sizes) && return 0
@@ -240,8 +238,8 @@ end
     base = 0
     tmp  = tid
     @inbounds for i in 1:length(outer_sizes)
-        q    = tmp ÷ outer_sizes[i]
-        r    = tmp - q * outer_sizes[i]
+        q     = tmp ÷ outer_sizes[i]
+        r     = tmp - q * outer_sizes[i]
         base += r * outer_strides[i]
         tmp   = q
     end
@@ -250,21 +248,22 @@ end
 
 @inline function _reduce_offset(j, reduce_strides, reduce_sizes)
     isempty(reduce_sizes) && return 0
-    # Single segment (the common case after canonicalization): j < reduce_size, so the
-    # decode is just j * stride — no per-element division.
+    # Single segment: j < reduce_size, so the decode is just j * stride — no division.
     length(reduce_sizes) == 1 && return j * reduce_strides[1]
     off = 0
     tmp = j
     @inbounds for i in 1:length(reduce_sizes)
-        q   = tmp ÷ reduce_sizes[i]
-        r   = tmp - q * reduce_sizes[i]
+        q    = tmp ÷ reduce_sizes[i]
+        r    = tmp - q * reduce_sizes[i]
         off += r * reduce_strides[i]
         tmp  = q
     end
     off
 end
 
-# GPU kernel: by_thread: one thread per output element
+# GPU kernel: by_thread — one thread per output element, reducing sequentially.
+# Used when there are more output elements than elements in the reduced dimension(s),
+# e.g. reduce(+, rand(3, 1000), dims=1) — only 3 elements to reduce per output.
 
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_thread!(
     @Const(src), dst,
@@ -273,6 +272,8 @@ end
     reduce_strides, reduce_sizes,
     output_size, reduce_size,
 )
+    # NOTE: index calculations use zero-indexing (fewer ops, matches the CUDA / ROCm / oneAPI /
+    # Metal code this is transpiled to), converting to one-indexing only at memory accesses.
     N       = @groupsize()[1]
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
@@ -291,7 +292,9 @@ end
     end
 end
 
-# GPU kernel: by_block: one block per output element, single group
+# GPU kernel: by_block — one block of threads cooperatively reduces each output element.
+# Used when there are more elements in the reduced dimension(s) than output elements,
+# e.g. reduce(+, rand(3, 1000), dims=2) — only 3 output elements.
 
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_block!(
     @Const(src), dst,
@@ -329,7 +332,9 @@ end
     end
 end
 
-# GPU kernel: multi-group
+# GPU kernel: multi-group first pass — several blocks per output element. Block `iblock`
+# handles output `iout` and group `igroup`, reducing its interleaved slice of the reduction
+# into partial[iout, igroup]. The second pass combines the groups.
 
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_multigroup!(
     @Const(src), partial,
@@ -367,14 +372,14 @@ end
     end
 end
 
-# GPU kernel: second pass — partial → dst
+# GPU kernel: multi-group second pass — one block per output reduces over the `reduce_groups`
+# partials and folds in `init`.
 
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_partial_to_dst!(
     @Const(partial), dst,
     op, init, neutral,
     output_size, reduce_groups,
 )
-    # One block per output element — block reduces over reduce_groups
     @uniform N = @groupsize()[1]
     sdata = @localmem eltype(dst) (N,)
 
@@ -382,7 +387,6 @@ end
     ithread = @index(Local, Linear) - 0x1
 
     if iblock < output_size
-        # Each thread strides over reduce_groups
         acc = neutral
         g = ithread
         while g < reduce_groups

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -178,12 +178,14 @@ function mapreduce_nd(
         length(reduce_sizes) == 1 && reduce_sizes[1] != 0 &&
         reduce_strides == (1,)
 
-    # by_block override 2: when by_thread would launch too few blocks, split each
-    # output reduction across a full block. This helps shapes like 1024×1024 dims=2
-    # where by_thread launches only four 256-thread blocks and each thread performs
-    # a long serial reduction.
+    # by_block override 2: when by_thread would launch too few blocks for a square
+    # output/reduction shape, split each output reduction across a full block. This
+    # helps shapes like 1024×1024 dims=2 where by_thread launches only four
+    # 256-thread blocks and each thread performs a long serial reduction. Avoid
+    # applying this to wide-output shapes, where by_thread's cross-output coalescing
+    # is better than a strided block reduction.
     use_by_block_for_low_occupancy =
-        dst_size >= reduce_size && reduce_size >= block_size &&
+        dst_size == reduce_size && reduce_size >= block_size &&
         cld(dst_size, block_size) < TARGET_BLOCKS &&
         length(reduce_sizes) == 1 && reduce_sizes[1] != 0
 

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -62,7 +62,7 @@ end
 function mapreduce_nd(
     f, op, src::MapReduceSource, backend::Backend;
     init,
-    neutral=neutral_element(op, eltype(src)),
+    neutral=neutral_element(op, _mapreduce_eltype(src)),
     dims::Union{Int, Tuple{Vararg{Int}}},
 
     # CPU settings

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -170,18 +170,26 @@ function mapreduce_nd(
     # option regardless of GS_DST_CUTOFF.
     # ─────────────────────────────────────────────────────────────────────────
 
-    # Coalescing override: when the reduced dimension is the fastest-varying one
-    # (reduce_strides==(1,)) and reduce_size is large enough to amortize a
-    # shared-memory tree-reduce (>=32, one warp), by_thread's per-thread strided
-    # access (stride==reduce_size across threads) is badly uncoalesced, while
-    # by_block lets consecutive threads read consecutive elements. Below 32,
-    # by_block's sync overhead isn't worth it for so few elements.
+    # by_block override 1: when the reduced dimension is the fastest-varying one
+    # (reduce_strides==(1,)), by_thread's per-thread strided access is badly
+    # uncoalesced, while by_block lets consecutive threads read consecutive elements.
     use_by_block_for_coalescing =
         dst_size >= reduce_size && reduce_size >= block_size &&
         length(reduce_sizes) == 1 && reduce_sizes[1] != 0 &&
         reduce_strides == (1,)
 
-    if dst_size >= reduce_size && !use_by_block_for_coalescing
+    # by_block override 2: when by_thread would launch too few blocks, split each
+    # output reduction across a full block. This helps shapes like 1024×1024 dims=2
+    # where by_thread launches only four 256-thread blocks and each thread performs
+    # a long serial reduction.
+    use_by_block_for_low_occupancy =
+        dst_size >= reduce_size && reduce_size >= block_size &&
+        cld(dst_size, block_size) < TARGET_BLOCKS &&
+        length(reduce_sizes) == 1 && reduce_sizes[1] != 0
+
+    use_by_block = use_by_block_for_coalescing || use_by_block_for_low_occupancy
+
+    if dst_size >= reduce_size && !use_by_block
         # Many outputs, small reduction: one thread per output reduces sequentially
         blocks = cld(dst_size, block_size)
         kernel! = _mapreduce_nd_by_thread!(backend, block_size)
@@ -191,9 +199,10 @@ function mapreduce_nd(
             dst_size, reduce_size,
             ndrange=(block_size * blocks,),
         )
-    elseif use_by_block_for_coalescing
-        # Grid-stride by_block: consecutive threads read consecutive (stride-1)
-        # elements of the reduced dimension -> coalesced.
+    elseif use_by_block
+        # Grid-stride by_block: one full block cooperates on each output, then
+        # grid-strides across remaining outputs if fewer blocks than outputs were
+        # launched.
         launch_blocks = min(dst_size, TARGET_BLOCKS)
         kernel! = _mapreduce_nd_by_block!(backend, block_size)
         kernel!(

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -309,8 +309,6 @@ end
 
 # GPU kernel: by_block: one block per output element, single group
 
-const _STAGING = 4
-
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_block!(
     @Const(src), dst,
     f, op, init, neutral,
@@ -327,16 +325,13 @@ const _STAGING = 4
     if iblock < output_size
         input_base = _outer_decode(iblock, outer_strides, outer_sizes)
 
+        # Pre-reduce in strides of N (consecutive threads read consecutive elements)
         acc = neutral
         j   = ithread
         while j < reduce_size
-            KernelAbstractions.Extras.@unroll for k in 1:_STAGING
-                if j < reduce_size
-                    off = _reduce_offset(j, reduce_strides, reduce_sizes)
-                    acc = op(acc, f(src[input_base + off + 0x1]))
-                    j  += N
-                end
-            end
+            off = _reduce_offset(j, reduce_strides, reduce_sizes)
+            acc = op(acc, f(src[input_base + off + 0x1]))
+            j  += N
         end
 
         sdata[ithread + 0x1] = acc
@@ -373,13 +368,9 @@ end
     acc = neutral
     j   = ithread + igroup * N
     while j < reduce_size
-        KernelAbstractions.Extras.@unroll for k in 1:_STAGING
-            if j < reduce_size
-                off = _reduce_offset(j, reduce_strides, reduce_sizes)
-                acc = op(acc, f(src[input_base + off + 0x1]))
-                j  += N * reduce_groups
-            end
-        end
+        off = _reduce_offset(j, reduce_strides, reduce_sizes)
+        acc = op(acc, f(src[input_base + off + 0x1]))
+        j  += N * reduce_groups
     end
 
     sdata[ithread + 0x1] = acc

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -49,7 +49,15 @@ function _canonicalize_dims(src_sizes, src_strides, dims_valid)
             end
             push!(reduce_segs, (seg_stride, seg_size))
         else
-            push!(outer_segs, (src_strides[i], src_sizes[i]))
+            seg_stride = src_strides[i]
+            seg_size   = src_sizes[i]
+            while i + 1 <= ndim &&
+                  !((i + 1) in dims_valid) &&
+                  src_strides[i + 1] == seg_stride * seg_size
+                i += 1
+                seg_size *= src_sizes[i]
+            end
+            push!(outer_segs, (seg_stride, seg_size))
         end
         i += 1
     end

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -60,7 +60,7 @@ end
 # Main entry point
 
 function mapreduce_nd(
-    f, op, src::AbstractArray, backend::Backend;
+    f, op, src::MapReduceSource, backend::Backend;
     init,
     neutral=neutral_element(op, eltype(src)),
     dims::Union{Int, Tuple{Vararg{Int}}},
@@ -142,7 +142,7 @@ function mapreduce_nd(
         return dst
     end
 
-    src_strides = strides(src)
+    src_strides = _mapreduce_strides(src)
     reduce_segs, outer_segs = _canonicalize_dims(src_sizes, src_strides, dims_valid)
 
     outer_strides  = Tuple(str for (str, _) in outer_segs)
@@ -271,6 +271,20 @@ function mapreduce_nd(
     end
 
     return dst
+end
+
+function _mapreduce_strides(src::AbstractArray)
+    return strides(src)
+end
+
+function _mapreduce_strides(src::Base.Broadcast.Broadcasted)
+    sizes = size(src)
+    stride = 1
+    return ntuple(length(sizes)) do i
+        s = stride
+        stride *= sizes[i]
+        s
+    end
 end
 
 

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -157,13 +157,15 @@ function mapreduce_nd(
         return dst
     end
 
-    # The stride-based fast paths below index the source by a flat linear offset
-    # (`src[offset + 1]`), which is only valid for a genuinely dense, column-major
-    # array. Any other source — strided views, adjoints, permuted dims, or a
-    # broadcast over such arrays — is reduced through the generic Cartesian-indexed
+    # The stride-based fast paths below index a flat buffer at
+    # `buffer[base_offset + Σ coordᵈ·strideᵈ + 1]`. This works for any source backed
+    # by a single dense column-major buffer (dense arrays, but also strided views,
+    # adjoints, permuted dims, and reshapes over one). Sources without such a buffer
+    # — `Broadcasted`, lazy/computed arrays — take the generic Cartesian-indexed
     # fallback, which makes no layout assumption (and crucially does not wrap the
     # source in `@Const`, which is what makes e.g. PermutedDimsArray uncompilable).
-    if !_mapreduce_fastpath_dense(src)
+    layout = _mapreduce_strided_layout(src)
+    if isnothing(layout)
         blocks = cld(dst_size, block_size)
         kernel! = _mapreduce_nd_generic!(backend, block_size)
         kernel!(
@@ -174,7 +176,7 @@ function mapreduce_nd(
         return dst
     end
 
-    src_strides = strides(src)
+    buffer, base_offset, src_strides = layout
     reduce_segs, outer_segs = _canonicalize_dims(src_sizes, src_strides, dims_valid)
 
     outer_strides  = Tuple(str for (str, _) in outer_segs)
@@ -240,8 +242,8 @@ function mapreduce_nd(
         blocks = cld(dst_size, rows_per_block)
         kernel! = _mapreduce_nd_by_thread_tiled_strided!(backend, block_size)
         kernel!(
-            src, dst, f, op, init, neutral,
-            reduce_strides[1], dst_size, reduce_size, Val(rows_per_block),
+            buffer, dst, f, op, init, neutral,
+            base_offset, reduce_strides[1], dst_size, reduce_size, Val(rows_per_block),
             ndrange=(block_size * blocks,),
         )
     elseif dst_size >= reduce_size && !use_by_block
@@ -249,8 +251,8 @@ function mapreduce_nd(
         blocks = cld(dst_size, block_size)
         kernel! = _mapreduce_nd_by_thread!(backend, block_size)
         kernel!(
-            src, dst, f, op, init,
-            outer_strides, outer_sizes, reduce_strides, reduce_sizes,
+            buffer, dst, f, op, init,
+            base_offset, outer_strides, outer_sizes, reduce_strides, reduce_sizes,
             dst_size, reduce_size,
             ndrange=(block_size * blocks,),
         )
@@ -261,8 +263,8 @@ function mapreduce_nd(
         launch_blocks = min(dst_size, TARGET_BLOCKS)
         kernel! = _mapreduce_nd_by_block!(backend, block_size)
         kernel!(
-            src, dst, f, op, init, neutral,
-            outer_strides, outer_sizes, reduce_strides, reduce_sizes,
+            buffer, dst, f, op, init, neutral,
+            base_offset, outer_strides, outer_sizes, reduce_strides, reduce_sizes,
             dst_size, reduce_size, launch_blocks,
             ndrange=(block_size * launch_blocks,),
         )
@@ -282,8 +284,8 @@ function mapreduce_nd(
 
             kernel! = _mapreduce_nd_multigroup!(backend, block_size)
             kernel!(
-                src, partial, f, op, neutral,
-                outer_strides, outer_sizes, reduce_strides, reduce_sizes,
+                buffer, partial, f, op, neutral,
+                base_offset, outer_strides, outer_sizes, reduce_strides, reduce_sizes,
                 Val(dst_size), reduce_size, reduce_groups,
                 ndrange=(block_size * dst_size * reduce_groups,),
             )
@@ -303,8 +305,8 @@ function mapreduce_nd(
             # single-block-per-output reduction directly, no partial array needed.
             kernel! = _mapreduce_nd_by_block!(backend, block_size)
             kernel!(
-                src, dst, f, op, init, neutral,
-                outer_strides, outer_sizes, reduce_strides, reduce_sizes,
+                buffer, dst, f, op, init, neutral,
+                base_offset, outer_strides, outer_sizes, reduce_strides, reduce_sizes,
                 dst_size, reduce_size, dst_size,
                 ndrange=(block_size * dst_size,),
             )
@@ -316,8 +318,8 @@ function mapreduce_nd(
         launch_blocks = min(dst_size, TARGET_BLOCKS)
         kernel! = _mapreduce_nd_by_block!(backend, block_size)
         kernel!(
-            src, dst, f, op, init, neutral,
-            outer_strides, outer_sizes, reduce_strides, reduce_sizes,
+            buffer, dst, f, op, init, neutral,
+            base_offset, outer_strides, outer_sizes, reduce_strides, reduce_sizes,
             dst_size, reduce_size, launch_blocks,
             ndrange=(block_size * launch_blocks,),
         )
@@ -335,20 +337,58 @@ function _mapreduce_dense_strides(sizes::Tuple)
     end
 end
 
-# Whether the stride-based fast-path kernels are valid for `src`: they index the
-# source by a flat linear offset, so they require a genuinely dense, column-major
-# array. A `Broadcasted` (and anything without dense `strides`) takes the generic
-# Cartesian-indexed fallback instead.
-function _mapreduce_fastpath_dense(src::AbstractArray)
+# Resolve the layout the stride-based fast-path kernels need. Those kernels index a
+# flat buffer at `buffer[base_offset + Σ coordᵈ·strideᵈ + 1]`, so they work for any
+# source backed by a single dense column-major buffer — a dense array, but also a
+# strided view, adjoint, permuted-dims, or reshape over one. Returns
+# `(buffer, base_offset, strides)` for such sources, or `nothing` (→ generic
+# Cartesian-indexed fallback) for `Broadcasted` and anything not backed by a dense
+# buffer (lazy/computed arrays, complex adjoints without `strides`, nested wrappers).
+function _mapreduce_strided_layout(src::AbstractArray)
+    s = try
+        strides(src)
+    catch err
+        err isa MethodError || rethrow()
+        return nothing
+    end
+
+    # Dense or contiguous (column-major) — index the source directly, no offset.
+    s == _mapreduce_dense_strides(size(src)) && return (src, 0, s)
+
+    # Non-dense but strided: index the dense parent buffer at the source's offset.
+    # Only one level of wrapping over a dense buffer is supported; deeper nesting
+    # falls back to the generic kernel.
+    p = parent(src)
+    (p === src || !_mapreduce_is_dense_buffer(p)) && return nothing
+    base = _mapreduce_wrapper_offset(src, p)
+    base === nothing && return nothing
+    return (p, base, s)
+end
+
+_mapreduce_strided_layout(::Base.Broadcast.Broadcasted) = nothing
+
+function _mapreduce_is_dense_buffer(p::AbstractArray)
     try
-        return strides(src) == _mapreduce_dense_strides(size(src))
+        return strides(p) == _mapreduce_dense_strides(size(p))
     catch err
         err isa MethodError || rethrow()
         return false
     end
 end
 
-_mapreduce_fastpath_dense(::Base.Broadcast.Broadcasted) = false
+# Offset (0-based, in elements) of the wrapper's first element within its dense
+# parent buffer. SubArrays start at their first selected index; permuted-dims,
+# reshapes, and (real) adjoints/transposes share the parent's first element.
+function _mapreduce_wrapper_offset(src::SubArray, p)
+    try
+        # Base.map (not AK's array `map`, which shadows it inside this module).
+        first_index = Base.map(first, parentindices(src))
+        return LinearIndices(p)[first_index...] - 1
+    catch
+        return nothing   # exotic index types → fall back to the generic kernel
+    end
+end
+_mapreduce_wrapper_offset(src, p) = 0
 
 # The reduced-extent index space: full axes along reduced dimensions, a single
 # index (`OneTo(1)`) along kept dimensions. Combined with `max(Iother, Ireduce)`
@@ -473,7 +513,7 @@ end
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_thread_tiled_strided!(
     @Const(src), dst,
     f, op, init, neutral,
-    reduce_stride,
+    base_offset, reduce_stride,
     output_size, reduce_size,
     ::Val{rows},
 ) where {rows}
@@ -492,9 +532,12 @@ end
 
     acc = neutral
     if iout < output_size
+        # Contiguous outputs (outer_strides == (1,)), so the source base is just iout;
+        # base_offset (0 for a dense source) is folded in once, outside the reduce loop.
+        sbase = base_offset + iout
         j = lane
         while j < reduce_size
-            acc = op(acc, f(src[iout + j * reduce_stride + 0x1]))
+            acc = op(acc, f(src[sbase + j * reduce_stride + 0x1]))
             j += reduce_threads
         end
     end
@@ -525,19 +568,22 @@ end
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_thread!(
     @Const(src), dst,
     f, op, init,
+    base_offset,
     outer_strides, outer_sizes,
     reduce_strides, reduce_sizes,
     output_size, reduce_size,
 )
     # NOTE: index calculations use zero-indexing (fewer ops, matches the CUDA / ROCm / oneAPI /
     # Metal code this is transpiled to), converting to one-indexing only at memory accesses.
+    # `base_offset` (the source's element offset within its dense buffer; 0 for a dense
+    # source) is folded into the per-output base, so it costs at most one add per thread.
     N       = @groupsize()[1]
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
     tid     = ithread + iblock * N
 
     if tid < output_size
-        input_base = _outer_decode(tid, outer_strides, outer_sizes)
+        input_base = base_offset + _outer_decode(tid, outer_strides, outer_sizes)
 
         res = init
         for j in 0x0:reduce_size - 0x1
@@ -562,6 +608,7 @@ end
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_block!(
     @Const(src), dst,
     f, op, init, neutral,
+    base_offset,
     outer_strides, outer_sizes,
     reduce_strides, reduce_sizes,
     output_size, reduce_size, num_blocks,
@@ -573,7 +620,7 @@ end
     ithread = @index(Local, Linear) - 0x1
     iout = iblock
     while true
-        input_base = _outer_decode(iout, outer_strides, outer_sizes)
+        input_base = base_offset + _outer_decode(iout, outer_strides, outer_sizes)
 
         acc = neutral
         j   = ithread
@@ -607,6 +654,7 @@ end
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_multigroup!(
     @Const(src), partial,
     f, op, neutral,
+    base_offset,
     outer_strides, outer_sizes,
     reduce_strides, reduce_sizes,
     ::Val{output_size}, reduce_size, reduce_groups,
@@ -623,7 +671,7 @@ end
     iout   = unsigned(iblock) % unsigned(output_size)
     igroup = unsigned(iblock) ÷ unsigned(output_size)
 
-    input_base = _outer_decode(iout, outer_strides, outer_sizes)
+    input_base = base_offset + _outer_decode(iout, outer_strides, outer_sizes)
 
     acc = neutral
     j   = ithread + igroup * N

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -2,7 +2,7 @@ function mapreduce_nd(
     f, op, src::AbstractArray, backend::Backend;
     init,
     neutral=neutral_element(op, eltype(src)),
-    dims::Int,
+    dims::Union{Int, Tuple{Vararg{Int}}},
 
     # CPU settings - ignored here
     max_tasks::Int,
@@ -18,7 +18,7 @@ function mapreduce_nd(
     # Degenerate cases begin; order of priority matters
 
     # Invalid dims
-    if dims < 1
+    if Base.any(d < 1 for d in (dims isa Int ? (dims,) : dims))
         throw(ArgumentError("region dimension(s) must be ≥ 1, got $dims"))
     end
 
@@ -27,7 +27,7 @@ function mapreduce_nd(
     #   julia> mapreduce(x -> -x, +, x, dims=3, init=Float32(0))
     #   3×5 Matrix{Float32}     # Negative numbers
     src_sizes = size(src)
-    if dims > length(src_sizes)
+    if Base.all(d > length(src_sizes) for d in (dims isa Int ? (dims,) : dims))
         if isnothing(temp)
             dst = KernelAbstractions.allocate(backend, typeof(init), src_sizes)
         else
@@ -42,7 +42,7 @@ function mapreduce_nd(
 
     # The per-dimension sizes of the destination array; construct tuple without allocations
     dst_sizes = unrolled_map_index(src_sizes) do i
-        i == dims ? 1 : src_sizes[i]
+        i in dims ? 1 : src_sizes[i]
     end
 
     # If any dimension except dims is zero, return empty similar array except with the dims
@@ -51,7 +51,7 @@ function mapreduce_nd(
     #   julia> reduce(+, x, dims=3)
     #   3×0×1 Array{Float64, 3}
     for isize in eachindex(src_sizes)
-        isize == dims && continue
+        isize in dims && continue
         if src_sizes[isize] == 0
             if isnothing(temp)
                 dst = KernelAbstractions.allocate(backend, typeof(init), dst_sizes)
@@ -73,7 +73,7 @@ function mapreduce_nd(
     #    0.0
     #    0.0
     #   [...]
-    len = src_sizes[dims]
+    len = Base.prod(src_sizes[d] for d in (dims isa Int ? (dims,) : dims))
     if len == 0
         if isnothing(temp)
             dst = KernelAbstractions.allocate(backend, typeof(init), dst_sizes)
@@ -118,72 +118,47 @@ function mapreduce_nd(
         _mapreduce_nd_cpu_sections!(
             f, op, dst, src;
             init,
-            dims,
             max_tasks=max_tasks,
             min_elems=min_elems,
         )
     else
-        # On GPUs we have two parallelisation approaches, based on which dimension has more elements:
-        #   - If the dimension we are reducing has more elements, (e.g. reduce(+, rand(3, 1000), dims=2)),
-        #     we use a block of threads per dst element - thus, a block of threads reduces the dims axis
-        #   - If the other dimensions have more elements (e.g. reduce(+, rand(3, 1000), dims=1)), we
-        #     use a single thread per dst element - thus, a thread reduces the dims axis sequentially,
-        #     while the other dimensions are processed in parallel, independently
-        if dst_size >= src_sizes[dims]
+        Rother  = CartesianIndices(dst)
+        Rreduce = CartesianIndices(ifelse.(axes(src) .== axes(dst), Ref(Base.OneTo(1)), axes(src)))
+
+        if dst_size >= len
             blocks = (dst_size + block_size - 1) ÷ block_size
             kernel1! = _mapreduce_nd_by_thread!(backend, block_size)
             kernel1!(
-                src, dst, f, op, init, dims,
+                src, dst, f, op, init, Rother, Rreduce,
                 ndrange=(block_size * blocks,),
             )
         else
-            # One block per output element
             blocks = dst_size
             kernel2! = _mapreduce_nd_by_block!(backend, block_size)
             kernel2!(
-                src, dst, f, op, init, neutral, dims,
+                src, dst, f, op, init, neutral, Rother, Rreduce,
                 ndrange=(block_size * blocks,),
             )
         end
     end
-
     return dst
 end
-
 
 function _mapreduce_nd_cpu_sections!(
     f, op, dst, src;
     init,
-    dims,
     max_tasks, min_elems,
 )
-    src_sizes = size(src)
-    src_strides = strides(src)
-    dst_strides = strides(dst)
+    Rother  = CartesianIndices(dst)
+    Rreduce = CartesianIndices(ifelse.(axes(src) .== axes(dst), Ref(Base.OneTo(1)), axes(src)))
 
-    reduce_size = src_sizes[dims]
-    ndims = length(src_sizes)
-
-    # Each thread handles a section of the output array - i.e. reducing along the dims, for
-    # multiple output strides
     foreachindex(dst, max_tasks=max_tasks, min_elems=min_elems) do idst
-
         @inbounds begin
-            # Compute the base index in src (excluding the reduced axis)
-            input_base_idx = 0
-            tmp = idst - 1
-            KernelAbstractions.Extras.@unroll for i in ndims:-1:1
-                if i != dims
-                    input_base_idx += (tmp ÷ dst_strides[i]) * src_strides[i]
-                end
-                tmp = tmp % dst_strides[i]
-            end
-
-            # Go over each element in the reduced dimension
+            Iother = Rother[idst]
             res = init
-            for i in 0:reduce_size - 1
-                src_idx = input_base_idx + i * src_strides[dims]
-                res = op(res, f(src[src_idx + 1]))
+            for Ireduce in Rreduce
+                J = max(Iother, Ireduce)
+                res = op(res, f(src[J]))
             end
             dst[idst] = res
         end
@@ -192,149 +167,70 @@ function _mapreduce_nd_cpu_sections!(
     dst
 end
 
-
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_thread!(
     @Const(src), dst,
     f, op,
-    init, dims,
+    init, Rother, Rreduce,
 )
-    # One thread per output element, when there are more outer elements than in the reduced dim
-    # e.g. reduce(+, rand(3, 1000), dims=1) => only 3 elements in the reduced dim
-    src_sizes = size(src)
-    src_strides = strides(src)
-    dst_sizes = size(dst)
-    dst_strides = strides(dst)
-
-    output_size = length(dst)
-    reduce_size = src_sizes[dims]
-
-    ndims = length(src_sizes)
+    # One thread per output element, when there are more outer elements than in the reduced dims
+    output_size = length(Rother)
+    reduce_size = length(Rreduce)
 
     N = @groupsize()[1]
 
-    # NOTE: for many index calculations in this library, computation using zero-indexing leads to
-    # fewer operations (also code is transpiled to CUDA / ROCm / oneAPI / Metal code which do zero
-    # indexing). Internal calculations will be done using zero indexing except when actually
-    # accessing memory. As with C, the lower bound is inclusive, the upper bound exclusive.
-
-    # Group (block) and local (thread) indices
-    iblock = @index(Group, Linear) - 0x1
+    iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
 
-    # Each thread handles one output element
     tid = ithread + iblock * N
     if tid < output_size
+        Iother = Rother[tid + 0x1]
 
-        # # Sometimes slightly faster method using additional memory with
-        # # output_idx = @private typeof(iblock) (ndims,)
-        # tmp = tid
-        # KernelAbstractions.Extras.@unroll for i in ndims:-1:1
-        #     output_idx[i] = tmp ÷ dst_strides[i]
-        #     tmp = tmp % dst_strides[i]
-        # end
-        # # Compute the base index in src (excluding the reduced axis)
-        # input_base_idx = 0
-        # KernelAbstractions.Extras.@unroll for i in 1:ndims
-        #     i == dims && continue
-        #     input_base_idx += output_idx[i] * src_strides[i]
-        # end
-
-        # Compute the base index in src (excluding the reduced axis)
-        input_base_idx = typeof(ithread)(0)
-        tmp = tid
-        KernelAbstractions.Extras.@unroll for i in ndims:-1i16:1i16
-            if i != dims
-                input_base_idx += (tmp ÷ dst_strides[i]) * src_strides[i]
-            end
-            tmp = tmp % dst_strides[i]
-        end
-
-        # Go over each element in the reduced dimension; this implementation assumes that there
-        # are so many outer elements (each processed by an independent thread) that we afford to
-        # loop sequentially over the reduced dimension (e.g. reduce(+, rand(3, 1000), dims=1))
         res = init
-        for i in 0x0:reduce_size - 0x1
-            src_idx = input_base_idx + i * src_strides[dims]
-            res = op(res, f(src[src_idx + 0x1]))
+        for i in 0x1:reduce_size
+            Ireduce = Rreduce[i]
+            J = max(Iother, Ireduce)
+            res = op(res, f(src[J]))
         end
-        dst[tid + 0x1] = res
+        dst[Iother] = res
     end
 end
-
 
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_block!(
     @Const(src), dst,
     f, op,
     init, neutral,
-    dims,
+    Rother, Rreduce,
 )
-    # One block per output element, when there are more elements in the reduced dim than in outer
+    # One block per output element, when there are more elements in the reduced dims than outer
     # e.g. reduce(+, rand(3, 1000), dims=2) => only 3 elements in outer dimensions
-    src_sizes = size(src)
-    src_strides = strides(src)
-    dst_sizes = size(dst)
-    dst_strides = strides(dst)
-
-    output_size = length(dst)
-    reduce_size = src_sizes[dims]
-
-    ndims = length(src_sizes)
+    reduce_size = length(Rreduce)
 
     @uniform N = @groupsize()[1]
     sdata = @localmem eltype(dst) (N,)
 
-    # NOTE: for many index calculations in this library, computation using zero-indexing leads to
-    # fewer operations (also code is transpiled to CUDA / ROCm / oneAPI / Metal code which do zero
-    # indexing). Internal calculations will be done using zero indexing except when actually
-    # accessing memory. As with C, the lower bound is inclusive, the upper bound exclusive.
-
-    # Group (block) and local (thread) indices
-    iblock = @index(Group, Linear) - 0x1
+    iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
 
-    # Each block handles one output element - thus, iblock ∈ [0, output_size)
+    # Each block handles one output element
+    Iother = Rother[iblock + 0x1]
 
-    # # Sometimes slightly faster method using additional memory with
-    # # output_idx = @private typeof(iblock) (ndims,)
-    # tmp = iblock
-    # KernelAbstractions.Extras.@unroll for i in ndims:-1:1
-    #     output_idx[i] = tmp ÷ dst_strides[i]
-    #     tmp = tmp % dst_strides[i]
-    # end
-    # # Compute the base index in src (excluding the reduced axis)
-    # input_base_idx = 0
-    # KernelAbstractions.Extras.@unroll for i in 1:ndims
-    #     i == dims && continue
-    #     input_base_idx += output_idx[i] * src_strides[i]
-    # end
-
-    # Compute the base index in src (excluding the reduced axis)
-    input_base_idx = typeof(ithread)(0)
-    tmp = iblock
-    KernelAbstractions.Extras.@unroll for i in ndims:-1i16:1i16
-        if i != dims
-            input_base_idx += (tmp ÷ dst_strides[i]) * src_strides[i]
-        end
-        tmp = tmp % dst_strides[i]
-    end
-
-    # We have a block of threads to process the whole reduced dimension. First do pre-reduction
-    # in strides of N
+    # Pre-reduce in strides of N across the reduction space
     partial = neutral
-    i = ithread
-    while i < reduce_size
-        src_idx = input_base_idx + i * src_strides[dims]
-        partial = op(partial, f(src[src_idx + 0x1]))
+    i = ithread + 0x1
+    while i <= reduce_size
+        Ireduce = Rreduce[i]
+        J = max(Iother, Ireduce)
+        partial = op(partial, f(src[J]))
         i += N
     end
 
-    # Store partial result in shared memory; now we are down to a single block to reduce within
+    # Store partial result in shared memory and reduce within block
     sdata[ithread + 0x1] = partial
     @synchronize()
 
     @inline reduce_group!(@context, op, sdata, N, ithread)
 
     if ithread == 0x0
-        dst[iblock + 0x1] = op(init, sdata[0x1])
+        dst[Iother] = op(init, sdata[0x1])
     end
 end

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -1,7 +1,40 @@
 # Generalized N-dimensional mapreduce for GPU and CPU backends.
-# Uses stride-arithmetic-based indexing (no CartesianIndices in GPU kernels)
-# with multi-group reduction for large reduction dimensions.
-# Note: This file was developed with AI assistance (Claude, Anthropic).
+
+# 1. Dimension canonicalization: collapse adjacent reducible dims into contiguous segments
+# 2. ND decode happens ONCE outside the inner loop using Val{sizes} (compile-time div → mulhi)
+# 3. Inner loop is pure multiply-add, zero div/mod — compiler can vectorize
+# 4. Multi-group reduction for large reduce spaces
+# 5. Input staging (K elements per thread before shared memory)
+
+# Host-side canonicalization
+
+function _canonicalize_dims(src_sizes, src_strides, dims_valid)
+    ndim = length(src_sizes)
+    reduce_segs = Tuple{Int,Int}[]
+    outer_segs  = Tuple{Int,Int}[]
+
+    i = 1
+    while i <= ndim
+        if i in dims_valid
+            seg_stride = src_strides[i]
+            seg_size   = src_sizes[i]
+            while i + 1 <= ndim &&
+                  (i + 1) in dims_valid &&
+                  src_strides[i + 1] == seg_stride * seg_size
+                i += 1
+                seg_size *= src_sizes[i]
+            end
+            push!(reduce_segs, (seg_stride, seg_size))
+        else
+            push!(outer_segs, (src_strides[i], src_sizes[i]))
+        end
+        i += 1
+    end
+
+    return Tuple(reduce_segs), Tuple(outer_segs)
+end
+
+# Main entry point
 
 function mapreduce_nd(
     f, op, src::AbstractArray, backend::Backend;
@@ -20,22 +53,18 @@ function mapreduce_nd(
 )
     @argcheck 1 <= block_size <= 1024
 
-    # Normalize dims to a tuple
     dims_all = dims isa Int ? (dims,) : dims
 
-    # Invalid dims: negative or zero
     if Base.any(d < 1 for d in dims_all)
         throw(ArgumentError("region dimension(s) must be ≥ 1, got $dims"))
     end
 
-    src_sizes = size(src)
-    ndim = length(src_sizes)
+    src_sizes   = size(src)
+    src_strides = strides(src)
+    ndim        = length(src_sizes)
 
-    # Filter out-of-range dims (Base silently ignores them)
-    # e.g. dims=(1,4) on a 3D array → only dim 1 is reduced
     dims_valid = Tuple(d for d in dims_all if d <= ndim)
 
-    # If ALL dims are out of range, just map each element through f and add init
     if isempty(dims_valid)
         if isnothing(temp)
             dst = KernelAbstractions.allocate(backend, typeof(init), src_sizes)
@@ -49,12 +78,10 @@ function mapreduce_nd(
         return dst
     end
 
-    # Destination sizes: reduced dims become 1
     dst_sizes = unrolled_map_index(src_sizes) do i
         i in dims_valid ? 1 : src_sizes[i]
     end
 
-    # If any kept dimension is zero → return empty array
     for isize in eachindex(src_sizes)
         isize in dims_valid && continue
         if src_sizes[isize] == 0
@@ -69,10 +96,8 @@ function mapreduce_nd(
         end
     end
 
-    # Total number of elements being reduced per output element
     len = Base.prod(src_sizes[d] for d in dims_valid)
 
-    # If reduced dims are all zero → fill with init
     if len == 0
         if isnothing(temp)
             dst = KernelAbstractions.allocate(backend, typeof(init), dst_sizes)
@@ -86,7 +111,6 @@ function mapreduce_nd(
         return dst
     end
 
-    # If reduced dims are all 1 → just apply f element-wise
     if len == 1
         if isnothing(temp)
             dst = KernelAbstractions.allocate(backend, typeof(init), src_sizes)
@@ -100,7 +124,6 @@ function mapreduce_nd(
         return dst
     end
 
-    # Allocate destination
     if isnothing(temp)
         dst = KernelAbstractions.allocate(backend, typeof(init), dst_sizes)
     else
@@ -112,78 +135,83 @@ function mapreduce_nd(
     dst_size = length(dst)
 
     if !use_gpu_algorithm(backend, prefer_threads)
-        _mapreduce_nd_cpu_sections!(
-            f, op, dst, src;
-            init,
-            dims=dims_valid,
-            max_tasks=max_tasks,
-            min_elems=min_elems,
-        )
+        _mapreduce_nd_cpu_sections!(f, op, dst, src; init, dims=dims_valid, max_tasks, min_elems)
     else
-        # Precompute strides on host — passed as tuples to kernel
-        # This avoids CartesianIndices div/mod inside the kernel
-        src_str = strides(src)
-        dst_str = strides(dst)
+        reduce_segs, outer_segs = _canonicalize_dims(src_sizes, src_strides, dims_valid)
 
-        # reduce_strides: for each src dim, its stride if it's a reduced dim, else 0
-        # Used to walk through the reduced subspace
-        reduce_str = unrolled_map_index(src_str) do i
-            i in dims_valid ? src_str[i] : 0
+        outer_sizes_tup    = Tuple(s   for (_, s)   in outer_segs)
+        outer_strides_tup  = Tuple(str for (str, _) in outer_segs)
+        reduce_sizes_tup   = Tuple(s   for (_, s)   in reduce_segs)
+        reduce_strides_tup = Tuple(str for (str, _) in reduce_segs)
+
+        reduce_size   = len
+        # Multi-group heuristic:
+        # - Always use if reduce_size is very large (> 16 * block_size)
+        # - Skip if dst_size is tiny AND reduce_size is moderate (overhead dominates)
+        raw_groups = (reduce_size + block_size - 1) ÷ block_size
+        reduce_groups = if raw_groups <= 1
+            1
+        elseif dst_size >= block_size
+            raw_groups  # large output: always multi-group
+        elseif reduce_size > 16 * block_size
+            raw_groups  # large reduction: need multi-group regardless
+        else
+            1           # small output + moderate reduction: single-group wins
         end
 
-        if dst_size >= len
-            # More output elements than reduction elements → one thread per output
-            blocks = (dst_size + block_size - 1) ÷ block_size
-            kernel1! = _mapreduce_nd_by_thread!(backend, block_size)
-            kernel1!(
-                src, dst, f, op, init,
-                src_str, dst_str, reduce_str,
-                dst_size, len, ndim,
-                ndrange=(block_size * blocks,),
-            )
-        else
-            # More reduction elements than output elements → one block per output
-            reduce_groups = (len + block_size - 1) ÷ block_size
-
-            if reduce_groups == 1
-                # Single group — all threads in one block handle one output element
-                kernel2! = _mapreduce_nd_by_block!(backend, block_size)
-                kernel2!(
+        if reduce_groups == 1
+            if dst_size >= reduce_size
+                blocks = (dst_size + block_size - 1) ÷ block_size
+                kernel! = _mapreduce_nd_by_thread!(backend, block_size)
+                kernel!(
+                    src, dst, f, op, init,
+                    outer_strides_tup, Val(outer_sizes_tup),
+                    reduce_strides_tup, Val(reduce_sizes_tup),
+                    dst_size, reduce_size,
+                    ndrange=(block_size * blocks,),
+                )
+            else
+                kernel! = _mapreduce_nd_by_block!(backend, block_size)
+                kernel!(
                     src, dst, f, op, init, neutral,
-                    src_str, dst_str, reduce_str,
-                    dst_size, len, ndim,
+                    outer_strides_tup, Val(outer_sizes_tup),
+                    reduce_strides_tup, Val(reduce_sizes_tup),
+                    dst_size, reduce_size,
+                    ndrange=(block_size * dst_size,),
+                )
+            end
+        else
+            partial = KernelAbstractions.allocate(backend, typeof(init), (dst_size, reduce_groups))
+
+            kernel! = _mapreduce_nd_multigroup!(backend, block_size)
+            kernel!(
+                src, partial, f, op, neutral,
+                outer_strides_tup, Val(outer_sizes_tup),
+                reduce_strides_tup, Val(reduce_sizes_tup),
+                dst_size, reduce_size, reduce_groups,
+                ndrange=(block_size * dst_size * reduce_groups,),
+            )
+
+            # Second pass: reduce partial (dst_size × reduce_groups) → dst
+            if reduce_groups <= block_size
+                # Small enough: one block handles it sequentially — low overhead
+                kernel2! = _mapreduce_partial_to_dst!(backend, block_size)
+                kernel2!(
+                    partial, dst, op, init,
+                    dst_size, reduce_groups,
                     ndrange=(block_size * dst_size,),
                 )
             else
-                # Multi-group — multiple blocks per output element
-                # partial shape: (dst_sizes..., reduce_groups)
-                partial_sizes = (dst_sizes..., reduce_groups)
-                partial = KernelAbstractions.allocate(backend, typeof(init), partial_sizes)
-
-                partial_str = strides(partial)
-
-                kernel3! = _mapreduce_nd_by_block_multigroup!(backend, block_size)
-                kernel3!(
-                    src, partial, f, op, neutral,
-                    src_str, dst_str, reduce_str, partial_str,
-                    dst_size, len, reduce_groups, ndim,
-                    ndrange=(block_size * dst_size * reduce_groups,),
-                )
-
-                # Second pass: reduce partial → dst
-                # partial has shape (dst_sizes..., reduce_groups)
-                # treat last dim as the reduction dim
-                partial_dst_str = strides(partial)[1:ndim]  # strides of first ndim dims
-                reduce_str2 = unrolled_map_index(strides(partial)) do i
-                    i == ndim + 1 ? strides(partial)[ndim + 1] : 0
-                end
-
-                kernel4! = _mapreduce_nd_by_block!(backend, block_size)
-                kernel4!(
-                    partial, dst, identity, op, init, neutral,
-                    strides(partial), dst_str, reduce_str2,
-                    dst_size, reduce_groups, ndim + 1,
-                    ndrange=(block_size * dst_size,),
+                # Large: recurse with proper block reduction
+                dst_2d = reshape(dst, (dst_size, 1))
+                mapreduce_nd(
+                    identity, op, partial, backend;
+                    init,
+                    neutral,
+                    dims=2,
+                    max_tasks, min_elems, prefer_threads,
+                    block_size,
+                    temp=dst_2d,
                 )
             end
         end
@@ -192,13 +220,11 @@ function mapreduce_nd(
     return dst
 end
 
+# CPU path
 
-# CPU path — CartesianIndices is fine here
 function _mapreduce_nd_cpu_sections!(
     f, op, dst, src;
-    init,
-    dims,
-    max_tasks, min_elems,
+    init, dims, max_tasks, min_elems,
 )
     Rother  = CartesianIndices(dst)
     Rreduce = CartesianIndices(ifelse.(axes(src) .== axes(dst), Ref(Base.OneTo(1)), axes(src)))
@@ -214,64 +240,77 @@ function _mapreduce_nd_cpu_sections!(
             dst[idst] = res
         end
     end
-
     dst
 end
 
+# Index helpers
 
-# GPU kernel: one thread per output element
-# Uses stride arithmetic — no CartesianIndices
+@inline function _outer_decode(tid, outer_strides, ::Val{outer_sizes}) where outer_sizes
+    # Walk dims from smallest stride to largest stride (column-major order)
+    # outer_segs are already in column-major order (dim 1 first, lowest stride first)
+    # So we walk 1..N: extract the low-order index first
+    base = 0
+    tmp  = tid
+    @inbounds for i in 1:length(outer_sizes)
+        q    = tmp ÷ outer_sizes[i]
+        r    = tmp - q * outer_sizes[i]
+        base += r * outer_strides[i]
+        tmp   = q
+    end
+    base
+end
+
+@inline function _reduce_offset(j, reduce_strides, ::Val{reduce_sizes}) where reduce_sizes
+    # Walk from smallest stride to largest (column-major)
+    off = 0
+    tmp = j
+    @inbounds for i in 1:length(reduce_sizes)
+        q   = tmp ÷ reduce_sizes[i]
+        r   = tmp - q * reduce_sizes[i]
+        off += r * reduce_strides[i]
+        tmp  = q
+    end
+    off
+end
+
+# GPU kernel: by_thread: one thread per output element
+
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_thread!(
     @Const(src), dst,
     f, op, init,
-    src_str, dst_str, reduce_str,
-    output_size, reduce_size, ndim,
-)
-    N = @groupsize()[1]
+    outer_strides, ::Val{outer_sizes},
+    reduce_strides, ::Val{reduce_sizes},
+    output_size, reduce_size,
+) where {outer_sizes, reduce_sizes}
+    N       = @groupsize()[1]
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
-    tid = ithread + iblock * N
+    tid     = ithread + iblock * N
 
     if tid < output_size
-        # Compute base index in src for this output element
-        # Walk dst linear index → per-dim indices → src offset (skip reduced dims)
-        input_base_idx = typeof(ithread)(0)
-        tmp = tid
-        KernelAbstractions.Extras.@unroll for i in ndim:-1i16:1i16
-            if dst_str[i] > 0 && reduce_str[i] == 0
-                # This is a kept dim
-                dim_idx = tmp ÷ dst_str[i]
-                input_base_idx += dim_idx * src_str[i]
-            end
-            tmp = tmp % dst_str[i]
-        end
+        input_base = _outer_decode(tid, outer_strides, Val(outer_sizes))
 
-        # Walk through reduced subspace using reduce_str
         res = init
         for j in 0x0:reduce_size - 0x1
-            reduce_offset = typeof(ithread)(0)
-            tmp2 = j
-            KernelAbstractions.Extras.@unroll for i in ndim:-1i16:1i16
-                if reduce_str[i] > 0
-                    reduce_offset += (tmp2 ÷ (reduce_str[i] ÷ src_str[1])) * src_str[i]
-                    tmp2 = tmp2 % (reduce_str[i] ÷ src_str[1])
-                end
-            end
-            res = op(res, f(src[input_base_idx + reduce_offset + 0x1]))
+            off = _reduce_offset(j, reduce_strides, Val(reduce_sizes))
+            res = op(res, f(src[input_base + off + 0x1]))
         end
 
         dst[tid + 0x1] = res
     end
 end
 
+# GPU kernel: by_block: one block per output element, single group
 
-# GPU kernel: one block per output element, single group
+const _STAGING = 4
+
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_block!(
     @Const(src), dst,
     f, op, init, neutral,
-    src_str, dst_str, reduce_str,
-    output_size, reduce_size, ndim,
-)
+    outer_strides, ::Val{outer_sizes},
+    reduce_strides, ::Val{reduce_sizes},
+    output_size, reduce_size,
+) where {outer_sizes, reduce_sizes}
     @uniform N = @groupsize()[1]
     sdata = @localmem eltype(dst) (N,)
 
@@ -279,35 +318,21 @@ end
     ithread = @index(Local, Linear) - 0x1
 
     if iblock < output_size
-        # Compute base index in src for this output element
-        input_base_idx = typeof(ithread)(0)
-        tmp = iblock
-        KernelAbstractions.Extras.@unroll for i in ndim:-1i16:1i16
-            if reduce_str[i] == 0
-                dim_idx = tmp ÷ dst_str[i]
-                input_base_idx += dim_idx * src_str[i]
-            end
-            tmp = tmp % dst_str[i]
-        end
+        input_base = _outer_decode(iblock, outer_strides, Val(outer_sizes))
 
-        # Each thread reduces a strided slice of the reduce space
-        partial = neutral
-        j = ithread
+        acc = neutral
+        j   = ithread
         while j < reduce_size
-            reduce_offset = typeof(ithread)(0)
-            tmp2 = j
-            KernelAbstractions.Extras.@unroll for i in ndim:-1i16:1i16
-                if reduce_str[i] > 0
-                    s = reduce_str[i] ÷ src_str[1]
-                    reduce_offset += (tmp2 ÷ s) * src_str[i]
-                    tmp2 = tmp2 % s
+            KernelAbstractions.Extras.@unroll for k in 1:_STAGING
+                if j < reduce_size
+                    off = _reduce_offset(j, reduce_strides, Val(reduce_sizes))
+                    acc = op(acc, f(src[input_base + off + 0x1]))
+                    j  += N
                 end
             end
-            partial = op(partial, f(src[input_base_idx + reduce_offset + 0x1]))
-            j += N
         end
 
-        sdata[ithread + 0x1] = partial
+        sdata[ithread + 0x1] = acc
         @synchronize()
 
         @inline reduce_group!(@context, op, sdata, N, ithread)
@@ -318,54 +343,36 @@ end
     end
 end
 
+# GPU kernel: multi-group
 
-# GPU kernel: multi-group reduction — multiple blocks per output element
-# Writes partial results to a (dst_sizes..., reduce_groups) array
-@kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_block_multigroup!(
+@kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_multigroup!(
     @Const(src), partial,
     f, op, neutral,
-    src_str, dst_str, reduce_str, partial_str,
-    output_size, reduce_size, reduce_groups, ndim,
-)
+    outer_strides, ::Val{outer_sizes},
+    reduce_strides, ::Val{reduce_sizes},
+    output_size, reduce_size, reduce_groups,
+) where {outer_sizes, reduce_sizes}
     @uniform N = @groupsize()[1]
     sdata = @localmem eltype(partial) (N,)
 
     iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
 
-    # iblock encodes both which output element and which reduce group
-    iout   = iblock % output_size          # which output element
-    igroup = iblock ÷ output_size          # which reduce group
+    iout   = iblock % output_size
+    igroup = iblock ÷ output_size
 
-    # Compute base index in src for this output element
-    input_base_idx = typeof(ithread)(0)
-    tmp = iout
-    KernelAbstractions.Extras.@unroll for i in ndim:-1i16:1i16
-        if reduce_str[i] == 0
-            dim_idx = tmp ÷ dst_str[i]
-            input_base_idx += dim_idx * src_str[i]
-        end
-        tmp = tmp % dst_str[i]
-    end
-
-    # Each group handles a chunk of the reduce space
-    chunk_start = igroup * N + ithread    # starting position in reduce space
-    chunk_stride = N * reduce_groups      # stride across groups
+    input_base = _outer_decode(iout, outer_strides, Val(outer_sizes))
 
     acc = neutral
-    j = chunk_start
+    j   = ithread + igroup * N
     while j < reduce_size
-        reduce_offset = typeof(ithread)(0)
-        tmp2 = j
-        KernelAbstractions.Extras.@unroll for i in ndim:-1i16:1i16
-            if reduce_str[i] > 0
-                s = reduce_str[i] ÷ src_str[1]
-                reduce_offset += (tmp2 ÷ s) * src_str[i]
-                tmp2 = tmp2 % s
+        KernelAbstractions.Extras.@unroll for k in 1:_STAGING
+            if j < reduce_size
+                off = _reduce_offset(j, reduce_strides, Val(reduce_sizes))
+                acc = op(acc, f(src[input_base + off + 0x1]))
+                j  += N * reduce_groups
             end
         end
-        acc = op(acc, f(src[input_base_idx + reduce_offset + 0x1]))
-        j += chunk_stride
     end
 
     sdata[ithread + 0x1] = acc
@@ -374,8 +381,40 @@ end
     @inline reduce_group!(@context, op, sdata, N, ithread)
 
     if ithread == 0x0
-        # Write to partial[(iout linear), igroup+1]
-        partial_idx = iout + igroup * output_size
-        partial[partial_idx + 0x1] = sdata[0x1]
+        partial[iout + igroup * output_size + 0x1] = sdata[0x1]
+    end
+end
+
+# GPU kernel: second pass — partial → dst
+
+@kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_partial_to_dst!(
+    @Const(partial), dst,
+    op, init,
+    output_size, reduce_groups,
+)
+    # One block per output element — block reduces over reduce_groups
+    @uniform N = @groupsize()[1]
+    sdata = @localmem eltype(dst) (N,)
+
+    iblock  = @index(Group, Linear) - 0x1
+    ithread = @index(Local, Linear) - 0x1
+
+    if iblock < output_size
+        # Each thread strides over reduce_groups
+        acc = eltype(dst)(0)  # neutral for this pass — init applied at end
+        g = ithread
+        while g < reduce_groups
+            acc = op(acc, partial[iblock + g * output_size + 0x1])
+            g += N
+        end
+
+        sdata[ithread + 0x1] = acc
+        @synchronize()
+
+        @inline reduce_group!(@context, op, sdata, N, ithread)
+
+        if ithread == 0x0
+            dst[iblock + 0x1] = op(init, sdata[0x1])
+        end
     end
 end

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -8,10 +8,12 @@
 #   2. The inner reduce loop must avoid per-element integer division. For a single segment the
 #      element offset is just `j * stride`; only genuinely non-contiguous dim sets (e.g.
 #      `dims=(1,3)`) fall back to a per-element multi-dimensional decode.
-#   3. Three work decompositions, chosen by the relative sizes of the output and the reduction:
-#        - by_thread:  one thread per output (many outputs, small reduction)
-#        - by_block:   one block per output, grid-stride over outputs (few outputs, large reduction)
-#        - multigroup: several blocks per output, two-pass (dst_size==1 or very small dst_size)
+#   3. Four work decompositions, chosen by the relative sizes and strides of the output and
+#      the reduction:
+#        - by_thread:     one thread per output (many outputs, small reduction)
+#        - tiled_strided: several contiguous outputs per block, for square-like strided reductions
+#        - by_block:      one block per output, grid-stride over outputs (few outputs, large reduction)
+#        - multigroup:    several blocks per output, two-pass (dst_size==1 or very small dst_size)
 
 # Number of blocks the by_block / multigroup paths aim to launch, so a reduction with
 # few output elements can still fill the GPU. A heuristic GPU-occupancy target.
@@ -26,6 +28,10 @@ const GS_DST_CUTOFF = 32
 # Caps reduce_groups so splitting a reduction doesn't shrink per-thread work
 # below the point where launch/scheduling overhead dominates actual work.
 const MIN_ITEMS_PER_THREAD = 8
+
+# Number of contiguous output rows handled by each tiled-strided block. With the default
+# 256-thread block this gives 32 lanes per row.
+const TILED_STRIDED_ROWS_PER_BLOCK = 8
 
 
 # Host-side canonicalization: split the dimensions into reduced and kept ("outer") segments,
@@ -160,16 +166,16 @@ function mapreduce_nd(
     reduce_size    = len
 
     # ─────────────────────────────────────────────────────────────────────────
-    # Dispatch decision (see header comment for the three paths):
+    # Dispatch decision (see header comment for the four paths):
     #
-    #   - dst_size >= reduce_size                         -> by_thread
+    #   - square-like, contiguous output with strided input -> tiled_strided
+    #   - dst_size >= reduce_size                          -> by_thread
     #   - dst_size == 1, or dst_size < GS_DST_CUTOFF
-    #     (and dst_size < reduce_size)                    -> multigroup (split one
-    #                                                         reduction across blocks,
-    #                                                         needs a 2nd-pass combine)
-    #   - otherwise (GS_DST_CUTOFF <= dst_size < reduce_size)
-    #                                                      -> by_block, grid-striding
-    #                                                         over outputs, single pass
+    #     (and dst_size < reduce_size)                     -> multigroup (split one
+    #                                                          reduction across blocks,
+    #                                                          needs a 2nd-pass combine)
+    #   - otherwise (GS_DST_CUTOFF <= dst_size < reduce_size) -> by_block, grid-striding
+    #                                                            over outputs, single pass
     #
     # Rationale: grid-striding by_block launches `min(dst_size, TARGET_BLOCKS)` blocks;
     # for very small dst_size (e.g. 5 or 9) that under-fills an 84-SM GPU, so splitting
@@ -186,12 +192,12 @@ function mapreduce_nd(
         length(reduce_sizes) == 1 && reduce_sizes[1] != 0 &&
         reduce_strides == (1,)
 
-    # by_block override 2: when by_thread would launch too few blocks for a square
+    # by_block override 2: when by_thread would launch too few blocks for a square-like
     # output/reduction shape, split each output reduction across a full block. This
-    # helps shapes like 1024×1024 dims=2 where by_thread launches only four
-    # 256-thread blocks and each thread performs a long serial reduction. Avoid
-    # applying this to wide-output shapes, where by_thread's cross-output coalescing
-    # is better than a strided block reduction.
+    # fallback is mostly for layouts that do not satisfy the narrower tiled-strided
+    # pattern below; the common contiguous-output strided case uses tiled_strided.
+    # Avoid applying this to wide-output shapes, where by_thread's cross-output
+    # coalescing is better than a strided block reduction.
     use_by_block_for_low_occupancy =
         dst_size == reduce_size && reduce_size >= block_size &&
         cld(dst_size, block_size) < TARGET_BLOCKS &&
@@ -202,15 +208,17 @@ function mapreduce_nd(
         dst_size == reduce_size && reduce_size >= block_size &&
         length(outer_sizes) == 1 && outer_strides == (1,) &&
         length(reduce_sizes) == 1 && reduce_strides[1] > 1 &&
-        block_size % 8 == 0 && ispow2(block_size ÷ 8)
+        block_size % TILED_STRIDED_ROWS_PER_BLOCK == 0 &&
+        ispow2(block_size ÷ TILED_STRIDED_ROWS_PER_BLOCK)
 
     if use_tiled_strided
-        # Square-like row reductions with contiguous outputs and strided input
-        # reads, e.g. size=(1024,1024), dims=2. Several outputs share a block:
-        # small lane groups reduce one output each, preserving more cross-output
-        # memory coalescing than by_block while launching many more blocks than
-        # by_thread.
-        rows_per_block = 8
+        # Narrow layout-specific path: square-like row reductions with contiguous
+        # outputs and strided input reads, e.g. size=(1024,1024), dims=2. Several
+        # outputs share a block: small lane groups reduce one output each, preserving
+        # more cross-output memory coalescing than by_block while launching many more
+        # blocks than by_thread. This is the only extra kernel beyond the generic
+        # by_thread/by_block/multigroup shapes.
+        rows_per_block = TILED_STRIDED_ROWS_PER_BLOCK
         blocks = cld(dst_size, rows_per_block)
         kernel! = _mapreduce_nd_by_thread_tiled_strided!(backend, block_size)
         kernel!(
@@ -530,7 +538,7 @@ end
         @synchronize()
         iout = next_iout
     end
-   end
+end
 
 # GPU kernel: multi-group first pass — several blocks per output element. Block `iblock`
 # handles output `iout` and group `igroup`, reducing its interleaved slice of the reduction

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -332,12 +332,20 @@ end
     length(reduce_sizes) == 1 && return j * reduce_strides[1]
     off = 0
     tmp = j
-    @inbounds for i in 1:length(reduce_sizes)
-        q    = tmp ÷ reduce_sizes[i]
-        r    = tmp - q * reduce_sizes[i]
+    @inbounds for i in 1:length(reduce_sizes) - 1
+        sz = reduce_sizes[i]
+        if ispow2(sz)
+            shift = trailing_zeros(sz)
+            r   = tmp & (sz - 1)
+            tmp = tmp >> shift
+        else
+            q   = tmp ÷ sz
+            r   = tmp - q * sz
+            tmp = q
+        end
         off += r * reduce_strides[i]
-        tmp  = q
     end
+    off += tmp * reduce_strides[end]
     off
 end
 

--- a/src/reduce/mapreduce_nd.jl
+++ b/src/reduce/mapreduce_nd.jl
@@ -157,8 +157,24 @@ function mapreduce_nd(
         return dst
     end
 
-    src_strides = _mapreduce_strides(src)
-    _mapreduce_check_dense_strides(src, src_strides)
+    # The stride-based fast paths below index the source by a flat linear offset
+    # (`src[offset + 1]`), which is only valid for a genuinely dense, column-major
+    # array. Any other source — strided views, adjoints, permuted dims, or a
+    # broadcast over such arrays — is reduced through the generic Cartesian-indexed
+    # fallback, which makes no layout assumption (and crucially does not wrap the
+    # source in `@Const`, which is what makes e.g. PermutedDimsArray uncompilable).
+    if !_mapreduce_fastpath_dense(src)
+        blocks = cld(dst_size, block_size)
+        kernel! = _mapreduce_nd_generic!(backend, block_size)
+        kernel!(
+            src, dst, f, op, init,
+            CartesianIndices(dst), _mapreduce_reduce_indices(src, dst), dst_size,
+            ndrange=(block_size * blocks,),
+        )
+        return dst
+    end
+
+    src_strides = strides(src)
     reduce_segs, outer_segs = _canonicalize_dims(src_sizes, src_strides, dims_valid)
 
     outer_strides  = Tuple(str for (str, _) in outer_segs)
@@ -310,20 +326,6 @@ function mapreduce_nd(
     return dst
 end
 
-function _mapreduce_strides(src::AbstractArray)
-    return strides(src)
-end
-
-function _mapreduce_strides(src::Base.Broadcast.Broadcasted)
-    sizes = size(src)
-    stride = 1
-    return ntuple(length(sizes)) do i
-        s = stride
-        stride *= sizes[i]
-        s
-    end
-end
-
 function _mapreduce_dense_strides(sizes::Tuple)
     stride = 1
     return ntuple(length(sizes)) do i
@@ -333,16 +335,26 @@ function _mapreduce_dense_strides(sizes::Tuple)
     end
 end
 
-function _mapreduce_check_dense_strides(src::AbstractArray, src_strides)
-    dense_strides = _mapreduce_dense_strides(size(src))
-    src_strides == dense_strides && return nothing
-    throw(ArgumentError(
-        "GPU mapreduce with dims currently requires dense column-major source arrays; " *
-        "got strides $(src_strides), expected $(dense_strides)",
-    ))
+# Whether the stride-based fast-path kernels are valid for `src`: they index the
+# source by a flat linear offset, so they require a genuinely dense, column-major
+# array. A `Broadcasted` (and anything without dense `strides`) takes the generic
+# Cartesian-indexed fallback instead.
+function _mapreduce_fastpath_dense(src::AbstractArray)
+    try
+        return strides(src) == _mapreduce_dense_strides(size(src))
+    catch err
+        err isa MethodError || rethrow()
+        return false
+    end
 end
 
-_mapreduce_check_dense_strides(src::Base.Broadcast.Broadcasted, src_strides) = nothing
+_mapreduce_fastpath_dense(::Base.Broadcast.Broadcasted) = false
+
+# The reduced-extent index space: full axes along reduced dimensions, a single
+# index (`OneTo(1)`) along kept dimensions. Combined with `max(Iother, Ireduce)`
+# this reproduces Base's `mapreducedim!` iteration without touching strides.
+_mapreduce_reduce_indices(src, dst) =
+    CartesianIndices(ifelse.(axes(src) .== axes(dst), Ref(Base.OneTo(1)), axes(src)))
 
 
 # Smallest power-of-two >= n, capped at 256 (the original fixed block size) and
@@ -372,7 +384,7 @@ function _mapreduce_nd_cpu_sections!(
     init, max_tasks, min_elems,
 )
     Rother  = CartesianIndices(dst)
-    Rreduce = CartesianIndices(ifelse.(axes(src) .== axes(dst), Ref(Base.OneTo(1)), axes(src)))
+    Rreduce = _mapreduce_reduce_indices(src, dst)
 
     foreachindex(dst, max_tasks=max_tasks, min_elems=min_elems) do idst
         @inbounds begin
@@ -427,6 +439,35 @@ end
     end
     off += tmp * reduce_strides[end]
     off
+end
+
+# GPU kernel: generic fallback — one thread per output element, reducing sequentially
+# over the reduced extents using Cartesian indexing. Makes no assumption about the
+# source's memory layout, so it handles strided views, adjoints, permuted dims, and
+# broadcasts over them. Mirrors the CPU `_mapreduce_nd_cpu_sections!` path.
+#
+# NOTE: the source is deliberately NOT marked `@Const` here. `@Const` prevents the
+# `@inbounds` getindex of some wrappers (e.g. PermutedDimsArray's `genperm`) from
+# being elided, leaving a `throw` that the GPU backends cannot compile.
+@kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_generic!(
+    src, dst,
+    f, op, init,
+    Rother, Rreduce, output_size,
+)
+    N       = @groupsize()[1]
+    iblock  = @index(Group, Linear) - 0x1
+    ithread = @index(Local, Linear) - 0x1
+    tid     = ithread + iblock * N
+
+    if tid < output_size
+        Iother = Rother[tid + 0x1]
+        res = init
+        for Ireduce in Rreduce
+            J = max(Iother, Ireduce)
+            res = op(res, f(src[J]))
+        end
+        dst[Iother] = res
+    end
 end
 
 @kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_nd_by_thread_tiled_strided!(

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -78,8 +78,8 @@ The returned type is the same as `init` - to control output precision, specify `
 
 ## CPU settings
 Use at most `max_tasks` threads with at least `min_elems` elements per task. For N-dimensional
-arrays (`dims::Int`) multithreading currently only becomes faster for `max_tasks >= 4`; all other
-cases are scaling linearly with the number of threads.
+arrays (`dims` is an integer or tuple) multithreading currently only becomes faster for
+`max_tasks >= 4`; all other cases are scaling linearly with the number of threads.
 
 Note that multithreading reductions only improves performance for cases with more compute-heavy
 operations, which hide the memory latency and thread launch overhead - that includes:
@@ -174,8 +174,8 @@ are reduced without materializing the intermediate array. Mismatched axes throw
 
 ## CPU settings
 Use at most `max_tasks` threads with at least `min_elems` elements per task. For N-dimensional
-arrays (`dims::Int`) multithreading currently only becomes faster for `max_tasks >= 4`; all other
-cases are scaling linearly with the number of threads.
+arrays (`dims` is an integer or tuple) multithreading currently only becomes faster for
+`max_tasks >= 4`; all other cases are scaling linearly with the number of threads.
 
 ## GPU settings
 The `block_size` parameter controls the number of threads per block.

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -34,6 +34,14 @@ function _mapreduce_backend_from_args(args::Tuple)
     return backend
 end
 
+function _mapreduce_check_map_axes(src::AbstractArray, srcs::AbstractArray...)
+    src_axes = axes(src)
+    for other in srcs
+        axes(other) == src_axes || throw(DimensionMismatch("all input arrays must have the same axes"))
+    end
+    return nothing
+end
+
 include("mapreduce_1d_cpu.jl")
 include("mapreduce_1d_gpu.jl")
 include("mapreduce_nd.jl")
@@ -208,6 +216,7 @@ function mapreduce(
     init,
     kwargs...
 )
+    _mapreduce_check_map_axes(src, src2, srcs...)
     bc = Base.Broadcast.instantiate(Base.Broadcast.broadcasted(f, src, src2, srcs...))
     return mapreduce(
         identity, op, bc, _mapreduce_backend(bc);

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -155,6 +155,7 @@ end
     )
 
     mapreduce(f, op, A::AbstractArray, B::AbstractArray, As::AbstractArray...; init, kwargs...)
+    mapreduce(f, op, A::AbstractArray, B::AbstractArray, As::AbstractArray..., backend::Backend; init, kwargs...)
 
 Reduce `src` along dimensions `dims` using the binary operator `op` after applying `f` elementwise.
 If `dims` is `nothing` or `:`, reduce `src` to a scalar. If `dims` is an integer or a tuple of
@@ -216,6 +217,11 @@ Computing a two-input dimensional reduction:
 ```julia
 rows = AK.mapreduce((x, y) -> x * y, +, a, b; init=0f0, dims=1)
 ```
+
+An explicit backend may be passed after all input arrays:
+```julia
+rows = AK.mapreduce((x, y) -> x * y, +, a, b, backend; init=0f0, dims=1)
+```
 """
 function mapreduce(
     f, op, src::MapReduceSource, backend::Backend=_mapreduce_backend(src);
@@ -234,10 +240,37 @@ function mapreduce(
     init,
     kwargs...
 )
-    _mapreduce_check_map_axes(src, src2, srcs...)
-    bc = Base.Broadcast.instantiate(Base.Broadcast.broadcasted(f, src, src2, srcs...))
+    return _mapreduce_multi(
+        f, op, nothing, src, src2, srcs...;
+        init,
+        kwargs...
+    )
+end
+
+function mapreduce(
+    f, op, src::AbstractArray, src2::AbstractArray, arg, args...;
+    init,
+    kwargs...
+)
+    backend = isempty(args) ? arg : args[end]
+    backend isa Backend || throw(MethodError(mapreduce, (f, op, src, src2, arg, args...)))
+    srcs = isempty(args) ? () : (arg, args[1:end - 1]...)
+    return _mapreduce_multi(
+        f, op, backend, src, src2, srcs...;
+        init,
+        kwargs...
+    )
+end
+
+function _mapreduce_multi(
+    f, op, backend::Union{Nothing, Backend}, src::AbstractArray, srcs::AbstractArray...;
+    init,
+    kwargs...
+)
+    _mapreduce_check_map_axes(src, srcs...)
+    bc = Base.Broadcast.instantiate(Base.Broadcast.broadcasted(f, src, srcs...))
     return mapreduce(
-        identity, op, bc, _mapreduce_backend(bc);
+        identity, op, bc, isnothing(backend) ? _mapreduce_backend(bc) : backend;
         init,
         kwargs...
     )

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -10,7 +10,7 @@ include("mapreduce_nd.jl")
         op, src::AbstractArray, backend::Backend=get_backend(src);
         init,
         neutral=neutral_element(op, eltype(src)),
-        dims::Union{Nothing, Int}=nothing,
+        dims::Union{Nothing, Int, Tuple{Vararg{Int}}, Colon}=nothing,
 
         # CPU settings
         max_tasks::Int=Threads.nthreads(),
@@ -22,10 +22,10 @@ include("mapreduce_nd.jl")
         switch_below::Int=0,
     )
 
-Reduce `src` along dimensions `dims` using the binary operator `op`. If `dims` is `nothing`, reduce
-`src` to a scalar. If `dims` is an integer or a tuple of integers, reduce `src` along those
-dimension(s). The `init` value is used as the initial value for the reduction; `neutral` is the
-neutral element for the operator `op`.
+Reduce `src` along dimensions `dims` using the binary operator `op`. If `dims` is `nothing` or
+`:`, reduce `src` to a scalar. If `dims` is an integer or a tuple of integers, reduce `src` along
+those dimension(s). The `init` value is used as the initial value for the reduction; `neutral` is
+the neutral element for the operator `op`.
 
 The returned type is the same as `init` - to control output precision, specify `init` explicitly.
 
@@ -45,11 +45,12 @@ For non-memory-bound operations, reductions scale almost linearly with the numbe
 The `block_size` parameter controls the number of threads per block.
 
 The `temp` parameter can be used to pass a pre-allocated temporary array. For reduction to a scalar
-(`dims=nothing`), `length(temp) >= 2 * (length(src) + 2 * block_size - 1) ÷ (2 * block_size)` is
-required. For reduction along a dimension (`dims` is an integer), `temp` is used as the destination
-array, and thus must have the exact dimensions required - i.e. same dimensionwise sizes as `src`,
-except for the reduced dimension which becomes 1; there are some corner cases when one dimension is
-zero, check against `Base.reduce` for CPU arrays for exact behavior.
+(`dims=nothing` or `dims=:`), `length(temp) >= 2 * (length(src) + 2 * block_size - 1) ÷ (2 *
+block_size)` is required. For reduction along dimensions (`dims` is an integer or tuple), `temp` is
+used as the destination array, and thus must have the exact dimensions required - i.e. same
+dimensionwise sizes as `src`, except for the reduced dimension(s) which become 1; there are some
+corner cases when one dimension is zero, check against `Base.reduce` for CPU arrays for exact
+behavior.
 
 The `switch_below` parameter controls the threshold below which the reduction is performed on the
 CPU and is only used for 1D reductions (i.e. `dims=nothing`).
@@ -94,7 +95,7 @@ end
         f, op, src::AbstractArray, backend::Backend=get_backend(src);
         init,
         neutral=neutral_element(op, eltype(src)),
-        dims::Union{Nothing, Int}=nothing,
+        dims::Union{Nothing, Int, Tuple{Vararg{Int}}, Colon}=nothing,
 
         # CPU settings
         max_tasks::Int=Threads.nthreads(),
@@ -107,9 +108,9 @@ end
     )
 
 Reduce `src` along dimensions `dims` using the binary operator `op` after applying `f` elementwise.
-If `dims` is `nothing`, reduce `src` to a scalar. If `dims` is an integer or a tuple of integers,
-reduce `src` along those dimension(s). The `init` value is used as the initial value for the
-reduction (i.e. after mapping).
+If `dims` is `nothing` or `:`, reduce `src` to a scalar. If `dims` is an integer or a tuple of
+integers, reduce `src` along those dimension(s). The `init` value is used as the initial value for
+the reduction (i.e. after mapping).
 
 The `neutral` value is the neutral element (zero) for the operator `op`, which is needed for an
 efficient GPU implementation that also allows a nonzero `init`.
@@ -125,11 +126,12 @@ cases are scaling linearly with the number of threads.
 The `block_size` parameter controls the number of threads per block.
 
 The `temp` parameter can be used to pass a pre-allocated temporary array. For reduction to a scalar
-(`dims=nothing`), `length(temp) >= 2 * (length(src) + 2 * block_size - 1) ÷ (2 * block_size)` is
-required. For reduction along a dimension (`dims` is an integer), `temp` is used as the destination
-array, and thus must have the exact dimensions required - i.e. same dimensionwise sizes as `src`,
-except for the reduced dimension which becomes 1; there are some corner cases when one dimension is
-zero, check against `Base.reduce` for CPU arrays for exact behavior.
+(`dims=nothing` or `dims=:`), `length(temp) >= 2 * (length(src) + 2 * block_size - 1) ÷ (2 *
+block_size)` is required. For reduction along dimensions (`dims` is an integer or tuple), `temp` is
+used as the destination array, and thus must have the exact dimensions required - i.e. same
+dimensionwise sizes as `src`, except for the reduced dimension(s) which become 1; there are some
+corner cases when one dimension is zero, check against `Base.reduce` for CPU arrays for exact
+behavior.
 
 The `switch_below` parameter controls the threshold below which the reduction is performed on the
 CPU and is only used for 1D reductions (i.e. `dims=nothing`).
@@ -172,7 +174,7 @@ function _mapreduce_impl(
     f, op, src::AbstractArray, backend::Backend;
     init,
     neutral=neutral_element(op, eltype(src)),
-    dims::Union{Nothing, Int, Tuple{Vararg{Int}}} = nothing,
+    dims::Union{Nothing, Int, Tuple{Vararg{Int}}, Colon} = nothing,
 
     # CPU settings
     max_tasks::Int=Threads.nthreads(),
@@ -184,7 +186,7 @@ function _mapreduce_impl(
     temp::Union{Nothing, AbstractArray}=nothing,
     switch_below::Int=0,
 )
-    if isnothing(dims)
+    if isnothing(dims) || dims isa Colon
         if use_gpu_algorithm(backend, prefer_threads)
             mapreduce_1d_gpu(
                 f, op, src, backend;

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -293,6 +293,13 @@ function _mapreduce_impl(
     temp::Union{Nothing, AbstractArray}=nothing,
     switch_below::Int=0,
 )
+
+    # scalar *linear* indexing into a multidimensional Broadcasted object is
+    # only available on Julia 1.12; on earlier version, materialize it first.
+    if VERSION < v"1.12-" && src isa Base.Broadcast.Broadcasted
+        src = Base.Broadcast.materialize(src)
+    end
+
     if isnothing(dims) || dims isa Colon
         if use_gpu_algorithm(backend, prefer_threads)
             mapreduce_1d_gpu(

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -1,5 +1,39 @@
 # Backend implementations
 include("utilities.jl")
+
+const MapReduceSource = Union{AbstractArray, Base.Broadcast.Broadcasted}
+
+_mapreduce_eltype(src::AbstractArray) = eltype(src)
+_mapreduce_eltype(src::Base.Broadcast.Broadcasted) =
+    Base.Broadcast.combine_eltypes(identity, (src,))
+
+function _mapreduce_backend(src::AbstractArray)
+    return get_backend(src)
+end
+
+function _mapreduce_backend(src::Base.Broadcast.Broadcasted)
+    backend = _mapreduce_backend_from_args(src.args)
+    return isnothing(backend) ? CPU_BACKEND : backend
+end
+
+_mapreduce_backend_from_arg(src::AbstractArray) = get_backend(src)
+_mapreduce_backend_from_arg(src::Base.Broadcast.Broadcasted) = _mapreduce_backend(src)
+_mapreduce_backend_from_arg(_) = nothing
+
+function _mapreduce_backend_from_args(args::Tuple)
+    backend = nothing
+    for arg in args
+        arg_backend = _mapreduce_backend_from_arg(arg)
+        isnothing(arg_backend) && continue
+        if isnothing(backend)
+            backend = arg_backend
+        else
+            @argcheck arg_backend == backend
+        end
+    end
+    return backend
+end
+
 include("mapreduce_1d_cpu.jl")
 include("mapreduce_1d_gpu.jl")
 include("mapreduce_nd.jl")
@@ -76,7 +110,7 @@ mcolsum = AK.reduce(+, m; init=zero(eltype(m)), dims=2)
 ```
 """
 function reduce(
-    op, src::AbstractArray, backend::Backend=get_backend(src);
+    op, src::AbstractArray, backend::Backend=_mapreduce_backend(src);
     init,
     kwargs...
 )
@@ -158,7 +192,7 @@ mcolsumsq = AK.mapreduce(f, +, m; init=zero(eltype(m)), dims=2)
 ```
 """
 function mapreduce(
-    f, op, src::AbstractArray, backend::Backend=get_backend(src);
+    f, op, src::MapReduceSource, backend::Backend=_mapreduce_backend(src);
     init,
     kwargs...
 )
@@ -169,11 +203,24 @@ function mapreduce(
     )
 end
 
+function mapreduce(
+    f, op, src::AbstractArray, src2::AbstractArray, srcs::AbstractArray...;
+    init,
+    kwargs...
+)
+    bc = Base.Broadcast.instantiate(Base.Broadcast.broadcasted(f, src, src2, srcs...))
+    return mapreduce(
+        identity, op, bc, _mapreduce_backend(bc);
+        init,
+        kwargs...
+    )
+end
+
 
 function _mapreduce_impl(
-    f, op, src::AbstractArray, backend::Backend;
+    f, op, src::MapReduceSource, backend::Backend;
     init,
-    neutral=neutral_element(op, eltype(src)),
+    neutral=neutral_element(op, _mapreduce_eltype(src)),
     dims::Union{Nothing, Int, Tuple{Vararg{Int}}, Colon} = nothing,
 
     # CPU settings

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -89,7 +89,7 @@ operations, which hide the memory latency and thread launch overhead - that incl
 For non-memory-bound operations, reductions scale almost linearly with the number of threads.
 
 ## GPU settings
-The `block_size` parameter controls the number of threads per block.
+The `block_size` parameter controls the number of threads per block and must be a power of two.
 
 The `temp` parameter can be used to pass a pre-allocated temporary array. For reduction to a scalar
 (`dims=nothing` or `dims=:`), `length(temp) >= 2 * (length(src) + 2 * block_size - 1) ÷ (2 *
@@ -178,7 +178,7 @@ arrays (`dims` is an integer or tuple) multithreading currently only becomes fas
 `max_tasks >= 4`; all other cases are scaling linearly with the number of threads.
 
 ## GPU settings
-The `block_size` parameter controls the number of threads per block.
+The `block_size` parameter controls the number of threads per block and must be a power of two.
 
 The `temp` parameter can be used to pass a pre-allocated temporary array. For reduction to a scalar
 (`dims=nothing` or `dims=:`), `length(temp) >= 2 * (length(src) + 2 * block_size - 1) ÷ (2 *

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -60,7 +60,7 @@ include("mapreduce_nd.jl")
     reduce(
         op, src::AbstractArray, backend::Backend=get_backend(src);
         init,
-        neutral=neutral_element(op, eltype(src)),
+        neutral=neutral_element(op, typeof(init)),
         dims::Union{Nothing, Int, Tuple{Vararg{Int}}, Colon}=nothing,
 
         # CPU settings
@@ -145,7 +145,7 @@ end
     mapreduce(
         f, op, src::AbstractArray, backend::Backend=get_backend(src);
         init,
-        neutral=neutral_element(op, eltype(src)),
+        neutral=neutral_element(op, typeof(init)),
         dims::Union{Nothing, Int, Tuple{Vararg{Int}}, Colon}=nothing,
 
         # CPU settings
@@ -251,7 +251,7 @@ end
 function _mapreduce_impl(
     f, op, src::MapReduceSource, backend::Backend;
     init,
-    neutral=neutral_element(op, _mapreduce_eltype(src)),
+    neutral=neutral_element(op, typeof(init)),
     dims::Union{Nothing, Int, Tuple{Vararg{Int}}, Colon} = nothing,
 
     # CPU settings

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -158,6 +158,8 @@ end
         switch_below::Int=0,
     )
 
+    mapreduce(f, op, A::AbstractArray, B::AbstractArray, As::AbstractArray...; init, kwargs...)
+
 Reduce `src` along dimensions `dims` using the binary operator `op` after applying `f` elementwise.
 If `dims` is `nothing` or `:`, reduce `src` to a scalar. If `dims` is an integer or a tuple of
 integers, reduce `src` along those dimension(s). The `init` value is used as the initial value for
@@ -167,6 +169,12 @@ The `neutral` value is the neutral element (zero) for the operator `op`, which i
 efficient GPU implementation that also allows a nonzero `init`.
 
 The returned type is the same as `init` - to control output precision, specify `init` explicitly.
+
+Multiple input arrays are supported with the same axes. This follows `Base.mapreduce(f, op, A, B,
+...)` semantics: `f` is mapped across corresponding elements of the inputs and the mapped values
+are reduced without materializing the intermediate array. Mismatched axes throw
+`DimensionMismatch`; singleton-expanding broadcast semantics are reserved for internal
+`Broadcasted` sources used by array backends.
 
 ## CPU settings
 Use at most `max_tasks` threads with at least `min_elems` elements per task. For N-dimensional
@@ -206,6 +214,11 @@ f(x) = x * x
 m = MtlArray(rand(Int32(1):Int32(100), 10, 100_000))
 mrowsumsq = AK.mapreduce(f, +, m; init=zero(eltype(m)), dims=1)
 mcolsumsq = AK.mapreduce(f, +, m; init=zero(eltype(m)), dims=2)
+```
+
+Computing a two-input dimensional reduction:
+```julia
+rows = AK.mapreduce((x, y) -> x * y, +, a, b; init=0f0, dims=1)
 ```
 """
 function mapreduce(

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -8,7 +8,7 @@ _mapreduce_eltype(src::Base.Broadcast.Broadcasted) =
     Base.Broadcast.combine_eltypes(identity, (src,))
 
 function _mapreduce_backend(src::AbstractArray)
-    return get_backend(src)
+    return _mapreduce_get_backend(src)
 end
 
 function _mapreduce_backend(src::Base.Broadcast.Broadcasted)
@@ -16,7 +16,16 @@ function _mapreduce_backend(src::Base.Broadcast.Broadcasted)
     return isnothing(backend) ? CPU_BACKEND : backend
 end
 
-_mapreduce_backend_from_arg(src::AbstractArray) = get_backend(src)
+function _mapreduce_get_backend(src::AbstractArray)
+    try
+        return get_backend(src)
+    catch err
+        err isa ArgumentError || rethrow()
+        return CPU_BACKEND
+    end
+end
+
+_mapreduce_backend_from_arg(src::AbstractArray) = _mapreduce_get_backend(src)
 _mapreduce_backend_from_arg(src::Base.Broadcast.Broadcasted) = _mapreduce_backend(src)
 _mapreduce_backend_from_arg(_) = nothing
 

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -23,8 +23,9 @@ include("mapreduce_nd.jl")
     )
 
 Reduce `src` along dimensions `dims` using the binary operator `op`. If `dims` is `nothing`, reduce
-`src` to a scalar. If `dims` is an integer, reduce `src` along that dimension. The `init` value is
-used as the initial value for the reduction; `neutral` is the neutral element for the operator `op`.
+`src` to a scalar. If `dims` is an integer or a tuple of integers, reduce `src` along those
+dimension(s). The `init` value is used as the initial value for the reduction; `neutral` is the
+neutral element for the operator `op`.
 
 The returned type is the same as `init` - to control output precision, specify `init` explicitly.
 
@@ -106,8 +107,9 @@ end
     )
 
 Reduce `src` along dimensions `dims` using the binary operator `op` after applying `f` elementwise.
-If `dims` is `nothing`, reduce `src` to a scalar. If `dims` is an integer, reduce `src` along that
-dimension. The `init` value is used as the initial value for the reduction (i.e. after mapping).
+If `dims` is `nothing`, reduce `src` to a scalar. If `dims` is an integer or a tuple of integers,
+reduce `src` along those dimension(s). The `init` value is used as the initial value for the
+reduction (i.e. after mapping).
 
 The `neutral` value is the neutral element (zero) for the operator `op`, which is needed for an
 efficient GPU implementation that also allows a nonzero `init`.

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -3,10 +3,6 @@ include("utilities.jl")
 
 const MapReduceSource = Union{AbstractArray, Base.Broadcast.Broadcasted}
 
-_mapreduce_eltype(src::AbstractArray) = eltype(src)
-_mapreduce_eltype(src::Base.Broadcast.Broadcasted) =
-    Base.Broadcast.combine_eltypes(identity, (src,))
-
 function _mapreduce_backend(src::AbstractArray)
     return _mapreduce_get_backend(src)
 end
@@ -165,8 +161,8 @@ If `dims` is `nothing` or `:`, reduce `src` to a scalar. If `dims` is an integer
 integers, reduce `src` along those dimension(s). The `init` value is used as the initial value for
 the reduction (i.e. after mapping).
 
-The `neutral` value is the neutral element (zero) for the operator `op`, which is needed for an
-efficient GPU implementation that also allows a nonzero `init`.
+The `neutral` value is the neutral element for the operator `op`, which is needed for an efficient
+GPU implementation that also allows a nonzero `init`.
 
 The returned type is the same as `init` - to control output precision, specify `init` explicitly.
 

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -170,7 +170,7 @@ function _mapreduce_impl(
     f, op, src::AbstractArray, backend::Backend;
     init,
     neutral=neutral_element(op, eltype(src)),
-    dims::Union{Nothing, Int}=nothing,
+    dims::Union{Nothing, Int, Tuple{Vararg{Int}}} = nothing,
 
     # CPU settings
     max_tasks::Int=Threads.nthreads(),

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -384,6 +384,16 @@ end
     @test AK.mapreduce(abs, +, array_from_host(vh_colon); prefer_threads, init=Int32(0), dims=:) ==
         mapreduce(abs, +, vh_colon; init=Int32(0), dims=:)
 
+    # Multi-input mapreduce lowers through a broadcasted source.
+    vh_a = rand(Int32(-10):Int32(10), 4, 5, 6)
+    vh_b = rand(Int32(-10):Int32(10), 4, 5, 6)
+    v_a = array_from_host(vh_a)
+    v_b = array_from_host(vh_b)
+    @test AK.mapreduce((x, y) -> x * y, +, v_a, v_b; prefer_threads, init=Int32(0)) ==
+        mapreduce((x, y) -> x * y, +, vh_a, vh_b; init=Int32(0))
+    @test AK.mapreduce((x, y) -> x * y, +, v_a, v_b; prefer_threads, init=Int32(0), dims=:) ==
+        mapreduce((x, y) -> x * y, +, vh_a, vh_b; init=Int32(0), dims=:)
+
     # Testing different settings, enforcing change of type between f and op
     f(s, temp) = AK.mapreduce(
         p -> (p.x, p.y),
@@ -504,6 +514,16 @@ end
     vh_dup = rand(Int32(1):Int32(10), 3, 4, 5)
     @test Array(AK.mapreduce(-, +, array_from_host(vh_dup); prefer_threads, init=Int32(0), dims=(2,2))) ==
         mapreduce(-, +, vh_dup; init=Int32(0), dims=(2,2))
+
+    # Multi-input mapreduce with dimensional reductions.
+    vh_ma = rand(Int32(-10):Int32(10), 4, 5, 6)
+    vh_mb = rand(Int32(-10):Int32(10), 4, 5, 6)
+    v_ma = array_from_host(vh_ma)
+    v_mb = array_from_host(vh_mb)
+    for dims in (1, 2, (1, 2), (1, 3), (1, 2, 3), (2, 2))
+        @test Array(AK.mapreduce((x, y) -> x * y, +, v_ma, v_mb; prefer_threads, init=Int32(0), dims)) ==
+            mapreduce((x, y) -> x * y, +, vh_ma, vh_mb; init=Int32(0), dims)
+    end
 
     # min/max with dims: tests correct neutral element in partial reduction
     for dims in 1:3

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -222,6 +222,18 @@ end
         end
     end
 
+    # Duplicate dims should error
+    @test_throws ArgumentError AK.reduce(+, array_from_host(rand(Int32, 3, 4, 5)); prefer_threads, init=Int32(0), dims=(2,2))
+
+    # min/max with dims: tests correct neutral element in partial reduction
+    for dims in 1:3
+        n1 = rand(1:50); n2 = rand(1:50); n3 = rand(1:50)
+        vh = rand(Int32(1):Int32(100), n1, n2, n3)
+        v = array_from_host(vh)
+        @test Array(AK.reduce(min, v; prefer_threads, init=typemax(Int32), neutral=typemax(Int32), dims)) == minimum(vh; dims)
+        @test Array(AK.reduce(max, v; prefer_threads, init=typemin(Int32), neutral=typemin(Int32), dims)) == maximum(vh; dims)
+    end
+
     # Tuple dims support
     for dims in [(1,2), (1,3), (2,3), (1,2,3)]
         for n1 in [1, 5, 10], n2 in [1, 5, 10], n3 in [1, 5, 10]
@@ -467,6 +479,18 @@ end
             sh = Array(s)
             @test sh == mapreduce(-, +, vh; dims, init)
         end
+    end
+
+    # Duplicate dims should error
+    @test_throws ArgumentError AK.reduce(+, array_from_host(rand(Int32, 3, 4, 5)); prefer_threads, init=Int32(0), dims=(2,2))
+
+    # min/max with dims: tests correct neutral element in partial reduction
+    for dims in 1:3
+        n1 = rand(1:50); n2 = rand(1:50); n3 = rand(1:50)
+        vh = rand(Int32(1):Int32(100), n1, n2, n3)
+        v = array_from_host(vh)
+        @test Array(AK.reduce(min, v; prefer_threads, init=typemax(Int32), neutral=typemax(Int32), dims)) == minimum(vh; dims)
+        @test Array(AK.reduce(max, v; prefer_threads, init=typemin(Int32), neutral=typemin(Int32), dims)) == maximum(vh; dims)
     end
 
     # Tuple dims support

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -392,6 +392,13 @@ end
     @test AK.mapreduce(abs, +, array_from_host(vh_one); prefer_threads, init=Int32(10)) ==
         mapreduce(abs, +, vh_one; init=Int32(10))
 
+    vh_typechange = rand(Int32(-10):Int32(10), 4, 5)
+    f_typechange = x -> Float32(x) / 2
+    @test AK.mapreduce(f_typechange, +, array_from_host(vh_typechange); prefer_threads, init=0f0) ≈
+        mapreduce(f_typechange, +, vh_typechange; init=0f0)
+    @test Array(AK.mapreduce(f_typechange, +, array_from_host(vh_typechange); prefer_threads, init=0f0, dims=2)) ≈
+        mapreduce(f_typechange, +, vh_typechange; init=0f0, dims=2)
+
     # Multi-input mapreduce lowers through a broadcasted source.
     vh_a = rand(Int32(-10):Int32(10), 4, 5, 6)
     vh_b = rand(Int32(-10):Int32(10), 4, 5, 6)
@@ -401,6 +408,8 @@ end
         mapreduce((x, y) -> x * y, +, vh_a, vh_b; init=Int32(0))
     @test AK.mapreduce((x, y) -> x * y, +, v_a, v_b; prefer_threads, init=Int32(0), dims=:) ==
         mapreduce((x, y) -> x * y, +, vh_a, vh_b; init=Int32(0), dims=:)
+    @test AK.mapreduce((x, y) -> Float32(x - y) / 3, +, v_a, v_b; prefer_threads, init=0f0) ≈
+        mapreduce((x, y) -> Float32(x - y) / 3, +, vh_a, vh_b; init=0f0)
 
     @test_throws DimensionMismatch AK.mapreduce(
         (x, y) -> x + y, +,
@@ -548,6 +557,8 @@ end
         @test Array(AK.mapreduce((x, y) -> x * y, +, v_ma, v_mb; prefer_threads, init=Int32(0), dims)) ==
             mapreduce((x, y) -> x * y, +, vh_ma, vh_mb; init=Int32(0), dims)
     end
+    @test Array(AK.mapreduce((x, y) -> Float32(x - y) / 3, +, v_ma, v_mb; prefer_threads, init=0f0, dims=(1, 2))) ≈
+        mapreduce((x, y) -> Float32(x - y) / 3, +, vh_ma, vh_mb; init=0f0, dims=(1, 2))
 
     # min/max with dims: tests correct neutral element in partial reduction
     for dims in 1:3

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -274,6 +274,10 @@ end
         vh = reshape(1:12, 1, 3, 4)
         @test Array(AK.reduce(+, vh, BACKEND; prefer_threads, init=0, dims=(1,2))) ==
             sum(vh; init=0, dims=(1,2))
+    else
+        vh = reshape(Int32(1):Int32(40), 5, 8)
+        v = array_from_host(vh)
+        @test_throws ArgumentError AK.reduce(+, @view(v[:, 1:2:end]); prefer_threads, init=Int32(0), dims=2)
     end
 
     # Test that undefined kwargs are not accepted
@@ -642,6 +646,10 @@ end
         vh = reshape(1:12, 1, 3, 4)
         @test Array(AK.mapreduce(x -> 2x, +, vh, BACKEND; prefer_threads, init=0, dims=(1,2))) ==
             mapreduce(x -> 2x, +, vh; init=0, dims=(1,2))
+    else
+        vh = reshape(Int32(1):Int32(40), 5, 8)
+        v = array_from_host(vh)
+        @test_throws ArgumentError AK.mapreduce(identity, +, @view(v[:, 1:2:end]); prefer_threads, init=Int32(0), dims=2)
     end
 
     # Test that undefined kwargs are not accepted

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -120,6 +120,11 @@ Base.zero(::Type{Point}) = Point(0.0f0, 0.0f0)
         @test s == reduce(+, vh)
     end
 
+    # Base-compatible alias: dims=: reduces all dimensions to a scalar.
+    vh_colon = rand(Int32(1):Int32(10), 3, 4, 5)
+    @test AK.reduce(+, array_from_host(vh_colon); prefer_threads, init=Int32(0), dims=:) ==
+        reduce(+, vh_colon; init=Int32(0), dims=:)
+
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.reduce(+, array_from_host(rand(Int32, 10)); init=10, bad=:kwarg)
 
@@ -374,6 +379,11 @@ end
         @test s == mapreduce(abs, +, vh)
     end
 
+    # Base-compatible alias: dims=: reduces all dimensions to a scalar.
+    vh_colon = rand(Int32(-10):Int32(10), 3, 4, 5)
+    @test AK.mapreduce(abs, +, array_from_host(vh_colon); prefer_threads, init=Int32(0), dims=:) ==
+        mapreduce(abs, +, vh_colon; init=Int32(0), dims=:)
+
     # Testing different settings, enforcing change of type between f and op
     f(s, temp) = AK.mapreduce(
         p -> (p.x, p.y),
@@ -592,6 +602,7 @@ end
     # Testing different settings
     v = array_from_host(rand(-5:5, 100_000))
     AK.sum(v; prefer_threads, block_size=64)
+    @test AK.sum(v; prefer_threads, dims=:) == sum(Array(v); dims=:)
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.sum(v; prefer_threads, bad=:kwarg)
@@ -637,6 +648,7 @@ end
     # Testing different settings
     v = array_from_host(rand(-5:5, 100_000))
     AK.prod(v; prefer_threads, block_size=64)
+    @test AK.prod(v; prefer_threads, dims=:) == prod(Array(v); dims=:)
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.prod(v; prefer_threads, bad=:kwarg)
@@ -682,6 +694,7 @@ end
     # Testing different settings
     v = array_from_host(rand(-5:5, 100_000))
     AK.minimum(v; prefer_threads, block_size=64)
+    @test AK.minimum(v; prefer_threads, dims=:) == minimum(Array(v); dims=:)
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.minimum(v; prefer_threads, bad=:kwarg)
@@ -727,6 +740,7 @@ end
     # Testing different settings
     v = array_from_host(rand(-5:5, 100_000))
     AK.maximum(v; prefer_threads, block_size=64)
+    @test AK.maximum(v; prefer_threads, dims=:) == maximum(Array(v); dims=:)
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.maximum(v; prefer_threads, bad=:kwarg)
@@ -779,6 +793,7 @@ end
     # Testing different settings
     v = array_from_host(rand(-5:5, 100_000))
     AK.count(x->x>0, v; prefer_threads, block_size=64)
+    @test AK.count(x->x>0, v; prefer_threads, dims=:) == count(x->x>0, Array(v); dims=:)
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.count(v; prefer_threads, bad=:kwarg)

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -275,11 +275,17 @@ end
         @test Array(AK.reduce(+, vh, BACKEND; prefer_threads, init=0, dims=(1,2))) ==
             sum(vh; init=0, dims=(1,2))
     else
-        # Non-dense GPU sources go through the generic Cartesian-indexed fallback.
+        # Strided GPU sources (views, adjoints, permuted dims) take the stride-based
+        # fast path over their dense parent buffer; the offset view exercises a nonzero
+        # base offset. Broadcasted/lazy sources still take the generic fallback.
         vh = reshape(Int32(1):Int32(40), 5, 8)
         v = array_from_host(vh)
         @test Array(AK.reduce(+, @view(v[:, 1:2:end]); prefer_threads, init=Int32(0), dims=2)) ==
             Base.reduce(+, @view(vh[:, 1:2:end]); init=Int32(0), dims=2)
+        @test Array(AK.reduce(+, @view(v[2:end, 1:2:end]); prefer_threads, init=Int32(0), dims=2)) ==
+            Base.reduce(+, @view(vh[2:end, 1:2:end]); init=Int32(0), dims=2)
+        @test Array(AK.reduce(+, v'; prefer_threads, init=Int32(0), dims=1)) ==
+            Base.reduce(+, vh'; init=Int32(0), dims=1)
         @test Array(AK.reduce(+, PermutedDimsArray(v, (2, 1)); prefer_threads, init=Int32(0), dims=1)) ==
             Base.reduce(+, PermutedDimsArray(vh, (2, 1)); init=Int32(0), dims=1)
     end
@@ -659,11 +665,15 @@ end
         @test Array(AK.mapreduce(x -> 2x, +, vh, BACKEND; prefer_threads, init=0, dims=(1,2))) ==
             mapreduce(x -> 2x, +, vh; init=0, dims=(1,2))
     else
-        # Non-dense GPU sources go through the generic Cartesian-indexed fallback.
+        # Strided GPU sources (views, adjoints, permuted dims) take the stride-based
+        # fast path over their dense parent buffer; the offset view exercises a nonzero
+        # base offset. Broadcasted/lazy sources still take the generic fallback.
         vh = reshape(Int32(1):Int32(40), 5, 8)
         v = array_from_host(vh)
         @test Array(AK.mapreduce(x -> x - Int32(1), +, @view(v[:, 1:2:end]); prefer_threads, init=Int32(0), dims=2)) ==
             mapreduce(x -> x - Int32(1), +, @view(vh[:, 1:2:end]); init=Int32(0), dims=2)
+        @test Array(AK.mapreduce(x -> x - Int32(1), +, @view(v[2:end, 1:2:end]); prefer_threads, init=Int32(0), dims=2)) ==
+            mapreduce(x -> x - Int32(1), +, @view(vh[2:end, 1:2:end]); init=Int32(0), dims=2)
         @test Array(AK.mapreduce(x -> x - Int32(1), +, PermutedDimsArray(v, (2, 1)); prefer_threads, init=Int32(0), dims=1)) ==
             mapreduce(x -> x - Int32(1), +, PermutedDimsArray(vh, (2, 1)); init=Int32(0), dims=1)
     end

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -245,8 +245,8 @@ end
         @test Array(AK.reduce(max, v; prefer_threads, init=typemin(Int32), neutral=typemin(Int32), dims)) == maximum(vh; dims)
     end
 
-    # Tuple dims support
-    for dims in [(1,2), (1,3), (2,3), (1,2,3)]
+    # Tuple dims support. Order and duplicates match Base semantics.
+    for dims in [(1,2), (1,3), (2,3), (1,2,3), (2,1), (3,1), (2,1,2)]
         for n1 in [1, 5, 10], n2 in [1, 5, 10], n3 in [1, 5, 10]
             vh = rand(Int32(1):Int32(100), n1, n2, n3)
             v = array_from_host(vh)
@@ -608,8 +608,8 @@ end
         @test Array(AK.reduce(max, v; prefer_threads, init=typemin(Int32), neutral=typemin(Int32), dims)) == maximum(vh; dims)
     end
 
-    # Tuple dims support
-    for dims in [(1,2), (1,3), (2,3), (1,2,3)]
+    # Tuple dims support. Order and duplicates match Base semantics.
+    for dims in [(1,2), (1,3), (2,3), (1,2,3), (2,1), (3,1), (2,1,2)]
         for n1 in [1, 5, 10], n2 in [1, 5, 10], n3 in [1, 5, 10]
             vh = rand(Int32(1):Int32(100), n1, n2, n3)
             v = array_from_host(vh)

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -408,8 +408,20 @@ end
         mapreduce((x, y) -> x * y, +, vh_a, vh_b; init=Int32(0))
     @test AK.mapreduce((x, y) -> x * y, +, v_a, v_b; prefer_threads, init=Int32(0), dims=:) ==
         mapreduce((x, y) -> x * y, +, vh_a, vh_b; init=Int32(0), dims=:)
+    @test Array(AK.mapreduce((x, y) -> x * y, +, v_a, v_b; prefer_threads, init=Int32(0), dims=())) ==
+        mapreduce((x, y) -> x * y, +, vh_a, vh_b; init=Int32(0), dims=())
     @test AK.mapreduce((x, y) -> Float32(x - y) / 3, +, v_a, v_b; prefer_threads, init=0f0) ≈
         mapreduce((x, y) -> Float32(x - y) / 3, +, vh_a, vh_b; init=0f0)
+
+    for (shape, dims) in (((0, 3), 1), ((2, 0), 2), ((0, 0), (1, 2)), ((0, 3), ()))
+        h_empty1 = reshape(Int32[], shape...)
+        h_empty2 = fill(Int32(2), shape...)
+        @test Array(AK.mapreduce((x, y) -> x + y, +,
+                                  array_from_host(h_empty1),
+                                  array_from_host(h_empty2);
+                                  prefer_threads, init=Int32(10), dims)) ==
+            mapreduce((x, y) -> x + y, +, h_empty1, h_empty2; init=Int32(10), dims)
+    end
 
     @test_throws DimensionMismatch AK.mapreduce(
         (x, y) -> x + y, +,
@@ -425,6 +437,8 @@ end
             mapreduce(identity, +, bc; init=0)
         @test Array(AK.mapreduce(identity, +, bc; prefer_threads, init=0, dims=2)) ==
             mapreduce(identity, +, bc; init=0, dims=2)
+        @test Array(AK.mapreduce(identity, +, bc; prefer_threads, init=0, dims=())) ==
+            mapreduce(identity, +, bc; init=0, dims=())
     end
 
     # Testing different settings, enforcing change of type between f and op
@@ -557,6 +571,8 @@ end
         @test Array(AK.mapreduce((x, y) -> x * y, +, v_ma, v_mb; prefer_threads, init=Int32(0), dims)) ==
             mapreduce((x, y) -> x * y, +, vh_ma, vh_mb; init=Int32(0), dims)
     end
+    @test Array(AK.mapreduce((x, y) -> x * y, +, v_ma, v_mb; prefer_threads, init=Int32(0), dims=())) ==
+        mapreduce((x, y) -> x * y, +, vh_ma, vh_mb; init=Int32(0), dims=())
     @test Array(AK.mapreduce((x, y) -> Float32(x - y) / 3, +, v_ma, v_mb; prefer_threads, init=0f0, dims=(1, 2))) ≈
         mapreduce((x, y) -> Float32(x - y) / 3, +, vh_ma, vh_mb; init=0f0, dims=(1, 2))
 

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -256,6 +256,16 @@ end
         end
     end
 
+    # Tiled strided GPU path: contiguous kept dimensions, one strided reduce
+    # dimension, and dst_size == reduce_size. The 3D case also exercises a
+    # partial output tile.
+    for (shape, dims) in (((512, 512), 2), ((20, 13, 260), 3))
+        vh = rand(Int32(1):Int32(3), shape...)
+        v = array_from_host(vh)
+        @test Array(AK.reduce(+, v; prefer_threads, init=Int32(0), dims)) ==
+            sum(vh; init=Int32(0), dims)
+    end
+
     if IS_CPU_BACKEND
         # The CPU fallback should not require strided storage.
         vh = reshape(1:12, 1, 3, 4)
@@ -607,6 +617,15 @@ end
             sh = Array(s)
             @test sh == mapreduce(-, +, vh; init=Int32(0), dims)
         end
+    end
+
+    # Tiled strided GPU path coverage for mapreduce, including a 3D case with
+    # a partial output tile.
+    for (shape, dims) in (((512, 512), 2), ((20, 13, 260), 3))
+        vh = rand(Int32(1):Int32(3), shape...)
+        v = array_from_host(vh)
+        @test Array(AK.mapreduce(x -> x - Int32(1), +, v; prefer_threads, init=Int32(0), dims)) ==
+            mapreduce(x -> x - Int32(1), +, vh; init=Int32(0), dims)
     end
 
     if IS_CPU_BACKEND

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -410,6 +410,14 @@ end
         init=Int32(0),
     )
 
+    if IS_CPU_BACKEND
+        bc = Base.Broadcast.instantiate(Base.Broadcast.broadcasted(+, reshape(1:6, 2, 3), reshape(10:15, 2, 3)))
+        @test AK.mapreduce(identity, +, bc; prefer_threads, init=0) ==
+            mapreduce(identity, +, bc; init=0)
+        @test Array(AK.mapreduce(identity, +, bc; prefer_threads, init=0, dims=2)) ==
+            mapreduce(identity, +, bc; init=0, dims=2)
+    end
+
     # Testing different settings, enforcing change of type between f and op
     f(s, temp) = AK.mapreduce(
         p -> (p.x, p.y),

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -222,8 +222,10 @@ end
         end
     end
 
-    # Duplicate dims should error
-    @test_throws ArgumentError AK.reduce(+, array_from_host(rand(Int32, 3, 4, 5)); prefer_threads, init=Int32(0), dims=(2,2))
+    # Duplicate dims match Base semantics and are reduced once.
+    vh_dup = rand(Int32(1):Int32(10), 3, 4, 5)
+    @test Array(AK.reduce(+, array_from_host(vh_dup); prefer_threads, init=Int32(0), dims=(2,2))) ==
+        sum(vh_dup; init=Int32(0), dims=(2,2))
 
     # min/max with dims: tests correct neutral element in partial reduction
     for dims in 1:3
@@ -243,6 +245,13 @@ end
             sh = Array(s)
             @test sh == sum(vh; dims)
         end
+    end
+
+    if IS_CPU_BACKEND
+        # The CPU fallback should not require strided storage.
+        vh = reshape(1:12, 1, 3, 4)
+        @test Array(AK.reduce(+, vh, BACKEND; prefer_threads, init=0, dims=(1,2))) ==
+            sum(vh; init=0, dims=(1,2))
     end
 
     # Test that undefined kwargs are not accepted
@@ -481,8 +490,10 @@ end
         end
     end
 
-    # Duplicate dims should error
-    @test_throws ArgumentError AK.reduce(+, array_from_host(rand(Int32, 3, 4, 5)); prefer_threads, init=Int32(0), dims=(2,2))
+    # Duplicate dims match Base semantics and are reduced once.
+    vh_dup = rand(Int32(1):Int32(10), 3, 4, 5)
+    @test Array(AK.mapreduce(-, +, array_from_host(vh_dup); prefer_threads, init=Int32(0), dims=(2,2))) ==
+        mapreduce(-, +, vh_dup; init=Int32(0), dims=(2,2))
 
     # min/max with dims: tests correct neutral element in partial reduction
     for dims in 1:3
@@ -502,6 +513,13 @@ end
             sh = Array(s)
             @test sh == mapreduce(-, +, vh; init=Int32(0), dims)
         end
+    end
+
+    if IS_CPU_BACKEND
+        # The CPU fallback should not require strided storage.
+        vh = reshape(1:12, 1, 3, 4)
+        @test Array(AK.mapreduce(x -> 2x, +, vh, BACKEND; prefer_threads, init=0, dims=(1,2))) ==
+            mapreduce(x -> 2x, +, vh; init=0, dims=(1,2))
     end
 
     # Test that undefined kwargs are not accepted

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -398,6 +398,12 @@ end
         mapreduce(f_typechange, +, vh_typechange; init=0f0)
     @test Array(AK.mapreduce(f_typechange, +, array_from_host(vh_typechange); prefer_threads, init=0f0, dims=2)) ≈
         mapreduce(f_typechange, +, vh_typechange; init=0f0, dims=2)
+    f_min_typechange = x -> Float32(10_000_000_000 + x)
+    f_max_typechange = x -> Float32(-10_000_000_000 + x)
+    @test AK.mapreduce(f_min_typechange, min, array_from_host(vh_typechange); prefer_threads, init=Inf32) ≈
+        mapreduce(f_min_typechange, min, vh_typechange; init=Inf32)
+    @test AK.mapreduce(f_max_typechange, max, array_from_host(vh_typechange); prefer_threads, init=-Inf32) ≈
+        mapreduce(f_max_typechange, max, vh_typechange; init=-Inf32)
 
     # Multi-input mapreduce lowers through a broadcasted source.
     vh_a = rand(Int32(-10):Int32(10), 4, 5, 6)
@@ -575,6 +581,13 @@ end
         mapreduce((x, y) -> x * y, +, vh_ma, vh_mb; init=Int32(0), dims=())
     @test Array(AK.mapreduce((x, y) -> Float32(x - y) / 3, +, v_ma, v_mb; prefer_threads, init=0f0, dims=(1, 2))) ≈
         mapreduce((x, y) -> Float32(x - y) / 3, +, vh_ma, vh_mb; init=0f0, dims=(1, 2))
+    vh_typechange_nd = rand(Int32(-10):Int32(10), 4, 5)
+    f_min_typechange_nd = x -> Float32(10_000_000_000 + x)
+    f_max_typechange_nd = x -> Float32(-10_000_000_000 + x)
+    @test Array(AK.mapreduce(f_min_typechange_nd, min, array_from_host(vh_typechange_nd); prefer_threads, init=Inf32, dims=2)) ≈
+        mapreduce(f_min_typechange_nd, min, vh_typechange_nd; init=Inf32, dims=2)
+    @test Array(AK.mapreduce(f_max_typechange_nd, max, array_from_host(vh_typechange_nd); prefer_threads, init=-Inf32, dims=2)) ≈
+        mapreduce(f_max_typechange_nd, max, vh_typechange_nd; init=-Inf32, dims=2)
 
     # min/max with dims: tests correct neutral element in partial reduction
     for dims in 1:3

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -428,10 +428,16 @@ end
     # Multi-input mapreduce lowers through a broadcasted source.
     vh_a = rand(Int32(-10):Int32(10), 4, 5, 6)
     vh_b = rand(Int32(-10):Int32(10), 4, 5, 6)
+    vh_c = rand(Int32(-10):Int32(10), 4, 5, 6)
     v_a = array_from_host(vh_a)
     v_b = array_from_host(vh_b)
+    v_c = array_from_host(vh_c)
     @test AK.mapreduce((x, y) -> x * y, +, v_a, v_b; prefer_threads, init=Int32(0)) ==
         mapreduce((x, y) -> x * y, +, vh_a, vh_b; init=Int32(0))
+    @test AK.mapreduce((x, y) -> x * y, +, v_a, v_b, BACKEND; prefer_threads, init=Int32(0)) ==
+        mapreduce((x, y) -> x * y, +, vh_a, vh_b; init=Int32(0))
+    @test AK.mapreduce((x, y, z) -> x + y * z, +, v_a, v_b, v_c, BACKEND; prefer_threads, init=Int32(0)) ==
+        mapreduce((x, y, z) -> x + y * z, +, vh_a, vh_b, vh_c; init=Int32(0))
     @test AK.mapreduce((x, y) -> x * y, +, v_a, v_b; prefer_threads, init=Int32(0), dims=:) ==
         mapreduce((x, y) -> x * y, +, vh_a, vh_b; init=Int32(0), dims=:)
     @test Array(AK.mapreduce((x, y) -> x * y, +, v_a, v_b; prefer_threads, init=Int32(0), dims=())) ==
@@ -600,6 +606,8 @@ end
         @test Array(AK.mapreduce((x, y) -> x * y, +, v_ma, v_mb; prefer_threads, init=Int32(0), dims)) ==
             mapreduce((x, y) -> x * y, +, vh_ma, vh_mb; init=Int32(0), dims)
     end
+    @test Array(AK.mapreduce((x, y) -> x * y, +, v_ma, v_mb, BACKEND; prefer_threads, init=Int32(0), dims=(1, 2))) ==
+        mapreduce((x, y) -> x * y, +, vh_ma, vh_mb; init=Int32(0), dims=(1, 2))
     @test Array(AK.mapreduce((x, y) -> x * y, +, v_ma, v_mb; prefer_threads, init=Int32(0), dims=())) ==
         mapreduce((x, y) -> x * y, +, vh_ma, vh_mb; init=Int32(0), dims=())
     @test Array(AK.mapreduce((x, y) -> Float32(x - y) / 3, +, v_ma, v_mb; prefer_threads, init=0f0, dims=(1, 2))) ≈

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -125,6 +125,10 @@ Base.zero(::Type{Point}) = Point(0.0f0, 0.0f0)
     @test AK.reduce(+, array_from_host(vh_colon); prefer_threads, init=Int32(0), dims=:) ==
         reduce(+, vh_colon; init=Int32(0), dims=:)
 
+    vh_one = Int32[7]
+    @test AK.reduce(+, array_from_host(vh_one); prefer_threads, init=Int32(10)) ==
+        reduce(+, vh_one; init=Int32(10))
+
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.reduce(+, array_from_host(rand(Int32, 10)); init=10, bad=:kwarg)
 
@@ -384,6 +388,10 @@ end
     @test AK.mapreduce(abs, +, array_from_host(vh_colon); prefer_threads, init=Int32(0), dims=:) ==
         mapreduce(abs, +, vh_colon; init=Int32(0), dims=:)
 
+    vh_one = Int32[-7]
+    @test AK.mapreduce(abs, +, array_from_host(vh_one); prefer_threads, init=Int32(10)) ==
+        mapreduce(abs, +, vh_one; init=Int32(10))
+
     # Multi-input mapreduce lowers through a broadcasted source.
     vh_a = rand(Int32(-10):Int32(10), 4, 5, 6)
     vh_b = rand(Int32(-10):Int32(10), 4, 5, 6)
@@ -393,6 +401,14 @@ end
         mapreduce((x, y) -> x * y, +, vh_a, vh_b; init=Int32(0))
     @test AK.mapreduce((x, y) -> x * y, +, v_a, v_b; prefer_threads, init=Int32(0), dims=:) ==
         mapreduce((x, y) -> x * y, +, vh_a, vh_b; init=Int32(0), dims=:)
+
+    @test_throws DimensionMismatch AK.mapreduce(
+        (x, y) -> x + y, +,
+        array_from_host(rand(Int32, 2, 3)),
+        array_from_host(rand(Int32, 1, 3));
+        prefer_threads,
+        init=Int32(0),
+    )
 
     # Testing different settings, enforcing change of type between f and op
     f(s, temp) = AK.mapreduce(

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -131,6 +131,9 @@ Base.zero(::Type{Point}) = Point(0.0f0, 0.0f0)
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.reduce(+, array_from_host(rand(Int32, 10)); init=10, bad=:kwarg)
+    if !IS_CPU_BACKEND
+        @test_throws ArgumentError AK.reduce(+, array_from_host(rand(Int32, 256)); prefer_threads, init=Int32(0), block_size=192)
+    end
 
     # Testing different settings
     AK.reduce(
@@ -275,6 +278,9 @@ end
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.reduce(+, array_from_host(rand(Int32, 10, 10)); prefer_threads, init=10, bad=:kwarg)
+    if !IS_CPU_BACKEND
+        @test_throws ArgumentError AK.reduce(+, array_from_host(rand(Int32, 16, 16)); prefer_threads, init=Int32(0), dims=1, block_size=192)
+    end
 
     # Testing different settings
     AK.reduce(
@@ -477,6 +483,9 @@ end
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.mapreduce(-, +, v; prefer_threads, init=10, bad=:kwarg)
+    if !IS_CPU_BACKEND
+        @test_throws ArgumentError AK.mapreduce(-, +, array_from_host(rand(Int32, 256)); prefer_threads, init=Int32(0), block_size=192)
+    end
 end
 
 
@@ -637,6 +646,9 @@ end
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.mapreduce(-, +, array_from_host(rand(Int32, 3, 4, 5)); prefer_threads, init=10, bad=:kwarg)
+    if !IS_CPU_BACKEND
+        @test_throws ArgumentError AK.mapreduce(-, +, array_from_host(rand(Int32, 16, 16)); prefer_threads, init=Int32(0), dims=1, block_size=192)
+    end
 
     # Testing different settings
     AK.mapreduce(

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -275,9 +275,13 @@ end
         @test Array(AK.reduce(+, vh, BACKEND; prefer_threads, init=0, dims=(1,2))) ==
             sum(vh; init=0, dims=(1,2))
     else
+        # Non-dense GPU sources go through the generic Cartesian-indexed fallback.
         vh = reshape(Int32(1):Int32(40), 5, 8)
         v = array_from_host(vh)
-        @test_throws ArgumentError AK.reduce(+, @view(v[:, 1:2:end]); prefer_threads, init=Int32(0), dims=2)
+        @test Array(AK.reduce(+, @view(v[:, 1:2:end]); prefer_threads, init=Int32(0), dims=2)) ==
+            Base.reduce(+, @view(vh[:, 1:2:end]); init=Int32(0), dims=2)
+        @test Array(AK.reduce(+, PermutedDimsArray(v, (2, 1)); prefer_threads, init=Int32(0), dims=1)) ==
+            Base.reduce(+, PermutedDimsArray(vh, (2, 1)); init=Int32(0), dims=1)
     end
 
     # Test that undefined kwargs are not accepted
@@ -655,9 +659,13 @@ end
         @test Array(AK.mapreduce(x -> 2x, +, vh, BACKEND; prefer_threads, init=0, dims=(1,2))) ==
             mapreduce(x -> 2x, +, vh; init=0, dims=(1,2))
     else
+        # Non-dense GPU sources go through the generic Cartesian-indexed fallback.
         vh = reshape(Int32(1):Int32(40), 5, 8)
         v = array_from_host(vh)
-        @test_throws ArgumentError AK.mapreduce(identity, +, @view(v[:, 1:2:end]); prefer_threads, init=Int32(0), dims=2)
+        @test Array(AK.mapreduce(x -> x - Int32(1), +, @view(v[:, 1:2:end]); prefer_threads, init=Int32(0), dims=2)) ==
+            mapreduce(x -> x - Int32(1), +, @view(vh[:, 1:2:end]); init=Int32(0), dims=2)
+        @test Array(AK.mapreduce(x -> x - Int32(1), +, PermutedDimsArray(v, (2, 1)); prefer_threads, init=Int32(0), dims=1)) ==
+            mapreduce(x -> x - Int32(1), +, PermutedDimsArray(vh, (2, 1)); init=Int32(0), dims=1)
     end
 
     # Test that undefined kwargs are not accepted

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -222,6 +222,17 @@ end
         end
     end
 
+    # Tuple dims support
+    for dims in [(1,2), (1,3), (2,3), (1,2,3)]
+        for n1 in [1, 5, 10], n2 in [1, 5, 10], n3 in [1, 5, 10]
+            vh = rand(Int32(1):Int32(100), n1, n2, n3)
+            v = array_from_host(vh)
+            s = AK.reduce(+, v; prefer_threads, init=Int32(0), dims)
+            sh = Array(s)
+            @test sh == sum(vh; dims)
+        end
+    end
+
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.reduce(+, array_from_host(rand(Int32, 10, 10)); prefer_threads, init=10, bad=:kwarg)
 
@@ -455,6 +466,17 @@ end
             s = AK.mapreduce(-, +, v; prefer_threads, init=Int32(init), dims)
             sh = Array(s)
             @test sh == mapreduce(-, +, vh; dims, init)
+        end
+    end
+
+    # Tuple dims support
+    for dims in [(1,2), (1,3), (2,3), (1,2,3)]
+        for n1 in [1, 5, 10], n2 in [1, 5, 10], n3 in [1, 5, 10]
+            vh = rand(Int32(1):Int32(100), n1, n2, n3)
+            v = array_from_host(vh)
+            s = AK.mapreduce(-, +, v; prefer_threads, init=Int32(0), dims)
+            sh = Array(s)
+            @test sh == mapreduce(-, +, vh; init=Int32(0), dims)
         end
     end
 


### PR DESCRIPTION
This PR extends `AcceleratedKernels.mapreduce` and `reduce` from single-dimension reductions to a more Base-compatible dimensional reduction implementation. It adds tuple `dims`, `dims=:`, `dims=()`, oversized and duplicate dims handling, type-changing `mapreduce`, and multi-input `mapreduce(f, op, A, B, ...; dims=...)`.

Notable API include:
- `dims` is now accepted as `Union{Nothing, Int, Tuple{Vararg{Int}}, Colon}` across `reduce`, `mapreduce`, and the arithmetic wrappers. Dimensional reductions now follow Base behavior for tuple dims, duplicate dims, dims beyond `ndims`, empty dims, colon dims, and zero-sized reduced or kept dimensions.
- Multi-input `mapreduce` is also supported, including an explicit backend argument after the input arrays.
- The default `neutral` is now derived from `typeof(init)`, preserving the documented result-type behavior for type-changing reductions.

### Implementation

The original CartesianIndices-only GPU approach was correct but too expensive for common reductions because it moved index decoding and integer division into hot loops. The final implementation keeps Cartesian indexing as a generic fallback, but uses stride-based fast paths for dense and strided GPU sources backed by a single dense column-major buffer.

For fast-path sources, `mapreduce_nd` resolves the layout to `(buffer, base_offset, strides)`. This lets views, offset views, adjoints, permuted dims, and reshapes use optimized flat-buffer kernels while still indexing the right underlying storage. Broadcasted, lazy, or otherwise non-dense sources use the generic fallback, which mirrors the CPU Cartesian path.

The kernel setup canonicalizes reduced and kept dimensions into contiguous stride segments. Common cases such as `dims=2` or `dims=(1, 2)` collapse to a single reduce segment and avoid per-element division entirely. Non-contiguous reductions such as `dims=(1, 3)` still use multi-segment decoding, with power-of-two segment sizes optimized via shift/mask operations.

GPU reductions dispatch between one-thread-per-output, tiled strided, one-block-per-output, and multigroup strategies. The heuristics were tuned to avoid the earlier regressions from overusing multigroup reductions while preserving occupancy and coalescing-sensitive cases.

### Performance

Several performance fixes were made: fast paths avoid hot-loop Cartesian indexing, common single-segment reductions avoid per-element division, multigroup reductions are gated to low-output large-reduction cases, `by_block` can grid-stride over outputs, and strided GPU sources now route through fast kernels instead of falling back unnecessarily.

The current implementation is broadly competitive with, and often faster than, the previous AK implementation and GPUArrays-style reductions across CUDA, Metal, and oneAPI. Remaining gaps are mostly backend-specialization opportunities such as subgroup collectives, vectorized loads/stores, small fixed-extent output-vectorized kernels, hardware-aware launch sizing, and selected vendor primitive dispatch.