### PR TITLE
Cleanup tests

### DIFF
--- a/test/generic/accumulate.jl
+++ b/test/generic/accumulate.jl
@@ -1,6 +1,6 @@
 ALGS = AK.AccumulateAlgorithm[AK.ScanPrefixes()]
 
-@isdefined(TEST_DL) && TEST_DL[] && push!(ALGS, AK.DecoupledLookback())
+TEST_DL && push!(ALGS, AK.DecoupledLookback())
 
 @testset "accumulate_1d $(alg isa AK.DecoupledLookback ? "DL" : "SP")" for alg in ALGS
 

--- a/test/generic/binarysearch.jl
+++ b/test/generic/binarysearch.jl
@@ -15,7 +15,7 @@
 
         vh = Array(v)
         xh = Array(x)
-        ixh = AK.searchsortedfirst(vh, xh; prefer_threads)
+        ixh = AK.searchsortedfirst(vh, xh; prefer_threads=true)
         ixh_base = [searchsortedfirst(vh, e) for e in xh]
 
         @test all(Array(ix) .== ixh .== ixh_base)
@@ -28,7 +28,7 @@
 
         vh = Array(v)
         xh = Array(x)
-        ixh = AK.searchsortedfirst(vh, xh; prefer_threads)
+        ixh = AK.searchsortedfirst(vh, xh; prefer_threads=true)
         ixh_base = [searchsortedfirst(vh, e) for e in xh]
 
         @test all(Array(ix) .== ixh .== ixh_base)
@@ -47,7 +47,7 @@
 
         vh = Array(v)
         xh = Array(x)
-        ixh = AK.searchsortedlast(vh, xh; prefer_threads)
+        ixh = AK.searchsortedlast(vh, xh; prefer_threads=true)
         ixh_base = [searchsortedlast(vh, e) for e in xh]
 
         @test all(Array(ix) .== ixh .== ixh_base)
@@ -60,7 +60,7 @@
 
         vh = Array(v)
         xh = Array(x)
-        ixh = AK.searchsortedlast(vh, xh; prefer_threads)
+        ixh = AK.searchsortedlast(vh, xh; prefer_threads=true)
         ixh_base = [searchsortedlast(vh, e) for e in xh]
 
         @test all(Array(ix) .== ixh .== ixh_base)
@@ -80,14 +80,14 @@
     xh = Array(x)
     ixh = similar(xh, Int32)
 
-    AK.searchsortedfirst!(ixh, vh, xh; prefer_threads, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100)
-    AK.searchsortedfirst(vh, xh; prefer_threads, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100)
-    AK.searchsortedlast!(ixh, vh, xh; prefer_threads, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100)
-    AK.searchsortedlast(vh, xh; prefer_threads, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100)
+    AK.searchsortedfirst!(ixh, vh, xh; prefer_threads=true, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100)
+    AK.searchsortedfirst(vh, xh; prefer_threads=true, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100)
+    AK.searchsortedlast!(ixh, vh, xh; prefer_threads=true, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100)
+    AK.searchsortedlast(vh, xh; prefer_threads=true, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100)
 
     # Test that undefined kwargs are not accepted
-    @test_throws MethodError AK.searchsortedfirst!(ixh, vh, xh; prefer_threads, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100, bad=:kwarg)
-    @test_throws MethodError AK.searchsortedfirst(vh, xh; prefer_threads, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100, bad=:kwarg)
-    @test_throws MethodError AK.searchsortedlast!(ixh, vh, xh; prefer_threads, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100, bad=:kwarg)
-    @test_throws MethodError AK.searchsortedlast(vh, xh; prefer_threads, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100, bad=:kwarg)
+    @test_throws MethodError AK.searchsortedfirst!(ixh, vh, xh; prefer_threads=true, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100, bad=:kwarg)
+    @test_throws MethodError AK.searchsortedfirst(vh, xh; prefer_threads=true, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100, bad=:kwarg)
+    @test_throws MethodError AK.searchsortedlast!(ixh, vh, xh; prefer_threads=true, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100, bad=:kwarg)
+    @test_throws MethodError AK.searchsortedlast(vh, xh; prefer_threads=true, by=abs, lt=(>), rev=true, max_tasks=10, min_elems=100, bad=:kwarg)
 end

--- a/test/generic/looping.jl
+++ b/test/generic/looping.jl
@@ -3,7 +3,7 @@
     Random.seed!(0)
 
     # CPU
-    if IS_CPU_BACKEND && prefer_threads
+    if prefer_threads
         x = zeros(Int, 1000)
         AK.foreachindex(x; prefer_threads) do i
             x[i] = i

--- a/test/generic/map.jl
+++ b/test/generic/map.jl
@@ -2,7 +2,7 @@
     Random.seed!(0)
 
     # CPU
-    if IS_CPU_BACKEND && prefer_threads
+    if prefer_threads
         x = Array(1:1000)
         y = AK.map(x; prefer_threads) do i
             i^2

--- a/test/generic/map.jl
+++ b/test/generic/map.jl
@@ -1,57 +1,34 @@
 @testset "map" begin
     Random.seed!(0)
 
-    # CPU
-    if prefer_threads
-        x = Array(1:1000)
-        y = AK.map(x; prefer_threads) do i
-            i^2
-        end
-        @test y == map(i -> i^2, x)
+    x = array_from_host(1:1000)
+    y = AK.map(x; prefer_threads) do i
+        i^2
+    end
+    @test Array(y) == map(i -> i^2, 1:1000)
 
-        x = Array(1:1000)
-        y = zeros(Int, 1000)
-        AK.map!(y, x; prefer_threads) do i
-            i^2
-        end
-        @test y == map(i -> i^2, x)
+    x = array_from_host(1:1000)
+    y = array_from_host(zeros(Int, 1000))
+    AK.map!(y, x; prefer_threads) do i
+        i^2
+    end
+    @test Array(y) == map(i -> i^2, 1:1000)
 
-        x = rand(Float32, 1000)
-        y = AK.map(x; prefer_threads, max_tasks=2, min_elems=100) do i
-            i > 0.5 ? i : 0
-        end
-        @test y == map(i -> i > 0.5 ? i : 0, x)
+    x = array_from_host(rand(Float32, 1000))
+    # Tests different things with GPU and CPU backends as well as irrelevant parameters being ignored
+    y = AK.map(x; prefer_threads, block_size=64, max_tasks=2, min_elems=100) do i
+        i > 0.5 ? i : 0
+    end
+    @test Array(y) == map(i -> i > 0.5 ? i : 0, Array(x))
 
+    if prefer_threads # CPU only
         x = rand(Float32, 1000)
         y = AK.map(x; prefer_threads, max_tasks=4, min_elems=500) do i
             i > 0.5 ? i : 0
         end
         @test y == map(i -> i > 0.5 ? i : 0, x)
-
-        # Test that undefined kwargs are not accepted
-        @test_throws MethodError AK.map(x -> x^2, x; prefer_threads, bad=:kwarg)
-    # GPU
-    else
-        x = array_from_host(1:1000)
-        y = AK.map(x; prefer_threads) do i
-            i^2
-        end
-        @test Array(y) == map(i -> i^2, 1:1000)
-
-        x = array_from_host(1:1000)
-        y = array_from_host(zeros(Int, 1000))
-        AK.map!(y, x; prefer_threads) do i
-            i^2
-        end
-        @test Array(y) == map(i -> i^2, 1:1000)
-
-        x = array_from_host(rand(Float32, 1000))
-        y = AK.map(x; prefer_threads, block_size=64) do i
-            i > 0.5 ? i : 0
-        end
-        @test Array(y) == map(i -> i > 0.5 ? i : 0, Array(x))
-
-        # Test that undefined kwargs are not accepted
-        @test_throws MethodError AK.map(x -> x^2, x; prefer_threads, bad=:kwarg)
     end
+
+    # Test that undefined kwargs are not accepted
+    @test_throws MethodError AK.map(x -> x^2, x; prefer_threads, bad=:kwarg)
 end

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -131,7 +131,7 @@ Base.zero(::Type{Point}) = Point(0.0f0, 0.0f0)
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.reduce(+, array_from_host(rand(Int32, 10)); init=10, bad=:kwarg)
-    if !IS_CPU_BACKEND
+    if !prefer_threads
         @test_throws ArgumentError AK.reduce(+, array_from_host(rand(Int32, 256)); prefer_threads, init=Int32(0), block_size=192)
     end
 
@@ -279,7 +279,7 @@ end
             sum(vh; init=Int32(0), dims)
     end
 
-    if IS_CPU_BACKEND
+    if prefer_threads
         # The CPU fallback should not require strided storage.
         vh = reshape(1:12, 1, 3, 4)
         @test Array(AK.reduce(+, vh, BACKEND; prefer_threads, init=0, dims=(1,2))) ==
@@ -302,7 +302,7 @@ end
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.reduce(+, array_from_host(rand(Int32, 10, 10)); prefer_threads, init=10, bad=:kwarg)
-    if !IS_CPU_BACKEND
+    if !prefer_threads
         @test_throws ArgumentError AK.reduce(+, array_from_host(rand(Int32, 16, 16)); prefer_threads, init=Int32(0), dims=1, block_size=192)
     end
 
@@ -483,7 +483,7 @@ end
         init=Int32(0),
     )
 
-    if IS_CPU_BACKEND
+    if prefer_threads
         bc = Base.Broadcast.instantiate(Base.Broadcast.broadcasted(+, reshape(1:6, 2, 3), reshape(10:15, 2, 3)))
         @test AK.mapreduce(identity, +, bc; prefer_threads, init=0) ==
             mapreduce(identity, +, bc; init=0)
@@ -513,7 +513,7 @@ end
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.mapreduce(-, +, v; prefer_threads, init=10, bad=:kwarg)
-    if !IS_CPU_BACKEND
+    if !prefer_threads
         @test_throws ArgumentError AK.mapreduce(-, +, array_from_host(rand(Int32, 256)); prefer_threads, init=Int32(0), block_size=192)
     end
 end
@@ -679,7 +679,7 @@ end
             mapreduce(x -> x - Int32(1), +, vh; init=Int32(0), dims)
     end
 
-    if IS_CPU_BACKEND
+    if prefer_threads
         # The CPU fallback should not require strided storage.
         vh = reshape(1:12, 1, 3, 4)
         @test Array(AK.mapreduce(x -> 2x, +, vh, BACKEND; prefer_threads, init=0, dims=(1,2))) ==
@@ -700,7 +700,7 @@ end
 
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.mapreduce(-, +, array_from_host(rand(Int32, 3, 4, 5)); prefer_threads, init=10, bad=:kwarg)
-    if !IS_CPU_BACKEND
+    if !prefer_threads
         @test_throws ArgumentError AK.mapreduce(-, +, array_from_host(rand(Int32, 16, 16)); prefer_threads, init=Int32(0), dims=1, block_size=192)
     end
 

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -150,7 +150,7 @@ Base.zero(::Type{Point}) = Point(0.0f0, 0.0f0)
     )
     AK.reduce(
         (x, y) -> x + 1,
-        rand(Int32, 10_000);
+        array_from_host(rand(Int32, 10_000));
         prefer_threads,
         init=Int32(0),
         neutral=Int64(0),
@@ -339,7 +339,7 @@ end
 @testset "mapreduce_1d" begin
     Random.seed!(0)
 
-    function minbox(s)
+    function minbox(s; prefer_threads)
         # Extract coordinates into tuple and reduce to find dimensionwise minima
         AK.mapreduce(
             p -> (p.x, p.y),
@@ -365,10 +365,10 @@ end
     for _ in 1:1000
         num_elems = rand(1:100_000)
         v = array_from_host([Point(rand(Float32), rand(Float32)) for _ in 1:num_elems])
-        mgpu = minbox(v)
+        mgpu = minbox(v; prefer_threads)
 
         vh = Array(v)
-        mcpu = minbox(vh)
+        mcpu = minbox(vh; prefer_threads=true)
         mbase = minbox_base(vh)
 
         @test typeof(mgpu) === typeof(mcpu) === typeof(mbase)
@@ -383,10 +383,10 @@ end
         n3 = rand(1:100)
 
         v = array_from_host([Point(rand(Float32), rand(Float32)) for _ in 1:n1, _ in 1:n2, _ in 1:n3])
-        mgpu = minbox(v)
+        mgpu = minbox(v; prefer_threads)
 
         vh = Array(v)
-        mcpu = minbox(vh)
+        mcpu = minbox(vh; prefer_threads=true)
         mbase = minbox_base(vh)
 
         @test typeof(mgpu) === typeof(mcpu) === typeof(mbase)
@@ -552,7 +552,7 @@ end
         end
     end
 
-    function minbox(s, dims)
+    function minbox(s, dims; prefer_threads)
         # Extract coordinates into tuple and reduce to find dimensionwise minima
         AK.mapreduce(
             p -> (p.x, p.y),
@@ -583,10 +583,10 @@ end
             n2 = rand(1:100)
             n3 = rand(1:100)
             v = array_from_host([Point(rand(Float32), rand(Float32)) for _ in 1:n1, _ in 1:n2, _ in 1:n3])
-            mgpu = minbox(v, dims)
+            mgpu = minbox(v, dims; prefer_threads)
 
             vh = Array(v)
-            mcpu = minbox(vh, dims)
+            mcpu = minbox(vh, dims; prefer_threads=true)
             mbase = minbox_base(vh, dims)
 
             @test eltype(mgpu) === eltype(mcpu) === eltype(mbase)

--- a/test/generic/sort.jl
+++ b/test/generic/sort.jl
@@ -1,4 +1,4 @@
-if !IS_CPU_BACKEND || !prefer_threads
+if !prefer_threads
 @testset "merge_sort" begin
     Random.seed!(0)
 
@@ -229,7 +229,7 @@ end
         issorted(vh[ixh]; kwargs...)
     end
 
-    if !IS_CPU_BACKEND || !prefer_threads
+    if !prefer_threads
         for T in filter(T -> T !== Float64 || KernelAbstractions.supports_float64(BACKEND),
                         (UInt32, Int32, Float32, UInt64, Int64, Float64))
             v_h = rand(T, 10_000)
@@ -277,7 +277,7 @@ end
 end
 
 
-if !IS_CPU_BACKEND || !prefer_threads
+if !prefer_threads
 @testset "merge_sort_by_key" begin
     Random.seed!(0)
 
@@ -359,7 +359,7 @@ end
 end
 
 
-if !IS_CPU_BACKEND || !prefer_threads
+if !prefer_threads
 @testset "merge_sortperm" begin
     Random.seed!(0)
 
@@ -468,7 +468,7 @@ end
 end
 
 
-if !IS_CPU_BACKEND || !prefer_threads
+if !prefer_threads
 @testset "merge_sortperm_lowmem" begin
     Random.seed!(0)
 
@@ -586,7 +586,7 @@ end
 end
 
 
-if !IS_CPU_BACKEND || !prefer_threads
+if !prefer_threads
 @testset "sortperm_extended" begin
     # Helper: ix is a valid permutation of 1:n that produces a sorted order
     function is_valid_perm(vh, ixh; kwargs...)
@@ -698,7 +698,7 @@ if !IS_CPU_BACKEND || !prefer_threads
 end
 
 @testset "radix_sort_alg" begin
-    if !IS_CPU_BACKEND || !prefer_threads
+    if !prefer_threads
         Random.seed!(0)
 
         # ── Correctness: fuzzy testing across supported types ─────────────────

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ if args.custom["cuda"] !== nothing
         using CUDACore
         global BACKEND = CUDABackend()
         global prefer_threads = false   # Also used to determine whether to run the CPU or GPU tests
-        global TEST_DL = Ref{Bool}(true)
+        global TEST_DL = true
         $_array_from_host_code
     end)
 end
@@ -61,7 +61,7 @@ if args.custom["amdgpu"] !== nothing
         using AMDGPU
         global BACKEND = ROCBackend()
         global prefer_threads = false   # Also used to determine whether to run the CPU or GPU tests
-        global TEST_DL = Ref{Bool}(true)
+        global TEST_DL = true
         $_array_from_host_code
     end)
 end
@@ -74,7 +74,7 @@ if args.custom["metal"] !== nothing
         using Metal
         global BACKEND = MetalBackend()
         global prefer_threads = false   # Also used to determine whether to run the CPU or GPU tests
-        global TEST_DL = Ref{Bool}(false)
+        global TEST_DL = false
         $_array_from_host_code
     end)
 end
@@ -87,7 +87,7 @@ if args.custom["oneapi"] !== nothing
         using oneAPI
         global BACKEND = oneAPIBackend()
         global prefer_threads = false   # Also used to determine whether to run the CPU or GPU tests
-        global TEST_DL = Ref{Bool}(false)
+        global TEST_DL = false
         $_array_from_host_code
     end)
 end
@@ -101,7 +101,7 @@ if args.custom["opencl"] !== nothing
         using OpenCL
         global BACKEND = OpenCLBackend()
         global prefer_threads = false   # Also used to determine whether to run the CPU or GPU tests
-        global TEST_DL = Ref{Bool}(false)
+        global TEST_DL = false
         $_array_from_host_code
     end)
 end
@@ -111,7 +111,7 @@ if args.custom["cpu-ka"] !== nothing
     push!(backends, "cpu-ka" => quote
         global BACKEND = get_backend([])
         global prefer_threads = false   # Also used to determine whether to run the CPU or GPU tests
-        global TEST_DL = Ref{Bool}(false)
+        global TEST_DL = false
         $_array_from_host_code
     end)
 end
@@ -121,7 +121,7 @@ if args.custom["cpu"] !== nothing || isempty(backends)
     push!(backends, "cpu" => quote
         global BACKEND = get_backend([])
         global prefer_threads = true    # Also used to determine whether to run the CPU or GPU tests
-        global TEST_DL = Ref{Bool}(false)
+        global TEST_DL = false
         $_array_from_host_code
     end)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ const _array_from_host_code = quote
     global array_from_host
     array_from_host(h_arr::AbstractArray, dtype=nothing) = array_from_host(BACKEND, h_arr, dtype)
     function array_from_host(backend, h_arr::AbstractArray, dtype=nothing)
-        d_arr = d_arr = if IS_CPU_BACKEND && prefer_threads # Don't use KA zeros if not using KA algorithms
+        d_arr = d_arr = if prefer_threads # Don't use KA zeros if not using KA algorithms
             zeros(isnothing(dtype) ? eltype(h_arr) : dtype, size(h_arr))
         else
             KernelAbstractions.zeros(backend, isnothing(dtype) ? eltype(h_arr) : dtype, size(h_arr))
@@ -46,8 +46,7 @@ if args.custom["cuda"] !== nothing
     push!(backends, "cuda" => quote
         using CUDACore
         global BACKEND = CUDABackend()
-        global IS_CPU_BACKEND = false
-        global prefer_threads = true
+        global prefer_threads = false   # Also used to determine whether to run the CPU or GPU tests
         global TEST_DL = Ref{Bool}(true)
         $_array_from_host_code
     end)
@@ -61,8 +60,7 @@ if args.custom["amdgpu"] !== nothing
     push!(backends, "amdgpu" => quote
         using AMDGPU
         global BACKEND = ROCBackend()
-        global IS_CPU_BACKEND = false
-        global prefer_threads = true
+        global prefer_threads = false   # Also used to determine whether to run the CPU or GPU tests
         global TEST_DL = Ref{Bool}(true)
         $_array_from_host_code
     end)
@@ -75,8 +73,7 @@ if args.custom["metal"] !== nothing
     push!(backends, "metal" => quote
         using Metal
         global BACKEND = MetalBackend()
-        global IS_CPU_BACKEND = false
-        global prefer_threads = true
+        global prefer_threads = false   # Also used to determine whether to run the CPU or GPU tests
         global TEST_DL = Ref{Bool}(false)
         $_array_from_host_code
     end)
@@ -89,8 +86,7 @@ if args.custom["oneapi"] !== nothing
     push!(backends, "oneapi" => quote
         using oneAPI
         global BACKEND = oneAPIBackend()
-        global IS_CPU_BACKEND = false
-        global prefer_threads = true
+        global prefer_threads = false   # Also used to determine whether to run the CPU or GPU tests
         global TEST_DL = Ref{Bool}(false)
         $_array_from_host_code
     end)
@@ -104,8 +100,7 @@ if args.custom["opencl"] !== nothing
         using pocl_jll
         using OpenCL
         global BACKEND = OpenCLBackend()
-        global IS_CPU_BACKEND = false
-        global prefer_threads = true
+        global prefer_threads = false   # Also used to determine whether to run the CPU or GPU tests
         global TEST_DL = Ref{Bool}(false)
         $_array_from_host_code
     end)
@@ -115,8 +110,7 @@ end
 if args.custom["cpu-ka"] !== nothing
     push!(backends, "cpu-ka" => quote
         global BACKEND = get_backend([])
-        global IS_CPU_BACKEND = true
-        global prefer_threads = false
+        global prefer_threads = false   # Also used to determine whether to run the CPU or GPU tests
         global TEST_DL = Ref{Bool}(false)
         $_array_from_host_code
     end)
@@ -126,8 +120,7 @@ end
 if args.custom["cpu"] !== nothing || isempty(backends)
     push!(backends, "cpu" => quote
         global BACKEND = get_backend([])
-        global IS_CPU_BACKEND = true
-        global prefer_threads = true
+        global prefer_threads = true    # Also used to determine whether to run the CPU or GPU tests
         global TEST_DL = Ref{Bool}(false)
         $_array_from_host_code
     end)


### PR DESCRIPTION
`TEST_DL` doesn't need to be a ref now that it's defined for every backend, `IS_CPU_BACKEND` is redundant with `prefer_threads`, and some tests could be deduplicated since `array_from_host` works on CPU arrays too.