### PR TITLE
Test predicate MapReduce algorithm with reduction tests

### DIFF
--- a/test/generic/predicates.jl
+++ b/test/generic/predicates.jl
@@ -29,19 +29,10 @@
         @test AK.all(x->x<0, v; prefer_threads) === false
     end
 
-    # Test the MapReduce algorithm which works on all platforms
-    for _ in 1:100
-        num_elems = rand(1:100_000)
-        v = array_from_host(rand(Float32, num_elems))
-        alg=AK.MapReduce(temp=similar(v, Bool), switch_below=100)
-        @test AK.any(x->x<0, v; prefer_threads, alg) === false
-        @test AK.any(x->x<1, v; prefer_threads, alg) === true
-        @test AK.all(x->x<1, v; prefer_threads, alg) === true
-        @test AK.all(x->x<0, v; prefer_threads, alg) === false
-    end
-
     # Testing different settings
     v = array_from_host(rand(-5:5, 100_000))
     AK.any(x->x<5, v; prefer_threads, max_tasks=2, min_elems=100, block_size=64)
     AK.all(x->x<5, v; prefer_threads, max_tasks=2, min_elems=100, block_size=64)
+
+    # The MapReduce algorithm is tested with the reductions tests
 end

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -969,3 +969,15 @@ end
 
     # The other settings are stress-tested in reduce
 end
+
+@testset "MapReduce predicates" begin
+    for _ in 1:100
+        num_elems = rand(1:100_000)
+        v = array_from_host(rand(Float32, num_elems))
+        alg=AK.MapReduce(temp=similar(v, Bool), switch_below=100)
+        @test AK.any(x->x<0, v; prefer_threads, alg) === false
+        @test AK.any(x->x<1, v; prefer_threads, alg) === true
+        @test AK.all(x->x<1, v; prefer_threads, alg) === true
+        @test AK.all(x->x<0, v; prefer_threads, alg) === false
+    end
+end


### PR DESCRIPTION
Since these tests failing would be due to the reduction algorithms as opposed to the predicate-only algorithms, this makes it clearer which tests actually fail especially when the failures are runner crashes