### PR TITLE
Make GPU reductions process multiple items per thread

### DIFF
--- a/src/reduce/mapreduce_1d_gpu.jl
+++ b/src/reduce/mapreduce_1d_gpu.jl
@@ -1,8 +1,9 @@
-@kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_block!(@Const(src), dst, f, op, neutral)
+# NI and K are compile-time values so the local-memory size is static and the load loop unrolls.
+@kernel inbounds=true cpu=false unsafe_indices=true function _mapreduce_block!(
+    @Const(src), dst, f, op, neutral, ::Val{NI}, ::Val{K},
+) where {NI, K}
 
-    @uniform N = @groupsize()[1]
-    sdata = @localmem eltype(dst) (N,)
-
+    sdata = @localmem eltype(dst) (NI,)
     len = length(src)
 
     # NOTE: for many index calculations in this library, computation using zero-indexing leads to
@@ -14,31 +15,20 @@
     iblock = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
 
-    i = ithread + iblock * (N * 0x2)
-    if i >= len
-        sdata[ithread + 0x1] = neutral
-    elseif i + N >= len
-        sdata[ithread + 0x1] = f(src[i + 0x1])
-    else
-        sdata[ithread + 0x1] = op(f(src[i + 0x1]), f(src[i + N + 0x1]))
+    # Consecutive threads load consecutive elements, while each thread advances by NI. Starting
+    # from neutral preserves the previous `op(neutral, x) == x` bootstrap.
+    acc = neutral
+    for s in 0x0:(K - 0x1)
+        idx = iblock * (NI * K) + s * NI + ithread
+        if idx < len
+            acc = op(acc, f(src[idx + 0x1]))
+        end
     end
+    sdata[ithread + 0x1] = acc
 
     @synchronize()
 
-    @inline reduce_group!(@context, op, sdata, N, ithread)
-
-    # Code below would work on NVidia GPUs with warp size of 32, but create race conditions and
-    # return incorrect results on Intel Graphics. It would be useful to have a way to statically
-    # query the warp size at compile time
-    #
-    # if ithread < 32
-    #     N >= 64 && (sdata[ithread + 1] = op(sdata[ithread + 1], sdata[ithread + 32 + 1]))
-    #     N >= 32 && (sdata[ithread + 1] = op(sdata[ithread + 1], sdata[ithread + 16 + 1]))
-    #     N >= 16 && (sdata[ithread + 1] = op(sdata[ithread + 1], sdata[ithread + 8 + 1]))
-    #     N >= 8 && (sdata[ithread + 1] = op(sdata[ithread + 1], sdata[ithread + 4 + 1]))
-    #     N >= 4 && (sdata[ithread + 1] = op(sdata[ithread + 1], sdata[ithread + 2 + 1]))
-    #     N >= 2 && (sdata[ithread + 1] = op(sdata[ithread + 1], sdata[ithread + 1 + 1]))
-    # end
+    @inline reduce_group!(@context, op, sdata, NI, ithread)
 
     if ithread == 0x0
         dst[iblock + 0x1] = sdata[0x1]
@@ -57,11 +47,13 @@ function mapreduce_1d_gpu(
 
     # GPU settings
     block_size::Int,
+    items_per_thread::Int,
     temp::Union{Nothing, AbstractArray},
     switch_below::Int,
 )
     @argcheck 1 <= block_size <= 1024
     @argcheck ispow2(block_size)
+    @argcheck items_per_thread >= 1
     @argcheck switch_below >= 0
 
     # Degenerate cases
@@ -73,8 +65,8 @@ function mapreduce_1d_gpu(
         return Base.mapreduce(f, op, h_src; init)
     end
 
-    # Each thread will handle two elements
-    num_per_block = 2 * block_size
+    # Each block handles `items_per_thread * block_size` elements.
+    num_per_block = items_per_thread * block_size
     blocks = (len + num_per_block - 1) ÷ num_per_block
 
     if !isnothing(temp)
@@ -93,7 +85,8 @@ function mapreduce_1d_gpu(
     dst_view = @view dst[1:blocks]
 
     kernel! = _mapreduce_block!(backend, block_size)
-    kernel!(src_view, dst_view, f, op, neutral, ndrange=(block_size * blocks,))
+    kernel!(src_view, dst_view, f, op, neutral, Val(block_size), Val(items_per_thread);
+            ndrange=(block_size * blocks,))
 
     # As long as we still have blocks to process, swap between the src and dst pointers at
     # the beginning of the first and second halves of dst
@@ -111,7 +104,8 @@ function mapreduce_1d_gpu(
         blocks = (len + num_per_block - 1) ÷ num_per_block
 
         # Each block produces one reduced value
-        kernel!(p1, p2, identity, op, neutral, ndrange=(block_size * blocks,))
+        kernel!(p1, p2, identity, op, neutral, Val(block_size), Val(items_per_thread);
+                ndrange=(block_size * blocks,))
         len = blocks
 
         if len < switch_below

--- a/src/reduce/reduce.jl
+++ b/src/reduce/reduce.jl
@@ -65,6 +65,7 @@ include("mapreduce_nd.jl")
 
         # GPU settings
         block_size::Int=256,
+        items_per_thread::Int=max(2, default_items_per_thread(backend)),
         temp::Union{Nothing, AbstractArray}=nothing,
         switch_below::Int=0,
     )
@@ -91,9 +92,13 @@ For non-memory-bound operations, reductions scale almost linearly with the numbe
 ## GPU settings
 The `block_size` parameter controls the number of threads per block and must be a power of two.
 
+The GPU-only `items_per_thread` parameter must be at least 1 and controls how many elements each
+thread reduces in a block-strided pass. Its default is
+`max(2, default_items_per_thread(backend))`; larger values can improve throughput on discrete GPUs.
+
 The `temp` parameter can be used to pass a pre-allocated temporary array. For reduction to a scalar
-(`dims=nothing` or `dims=:`), `length(temp) >= 2 * (length(src) + 2 * block_size - 1) ÷ (2 *
-block_size)` is required. For reduction along dimensions (`dims` is an integer or a collection of
+(`dims=nothing` or `dims=:`), `length(temp) >= 2 * cld(length(src), items_per_thread * block_size)`
+is required. For reduction along dimensions (`dims` is an integer or a collection of
 integers), `temp` is used as the destination array, and thus must have the exact dimensions required - i.e. same
 dimensionwise sizes as `src`, except for the reduced dimension(s) which become 1; there are some
 corner cases when one dimension is zero, check against `Base.reduce` for CPU arrays for exact
@@ -150,6 +155,7 @@ end
 
         # GPU settings
         block_size::Int=256,
+        items_per_thread::Int=max(2, default_items_per_thread(backend)),
         temp::Union{Nothing, AbstractArray}=nothing,
         switch_below::Int=0,
     )
@@ -181,9 +187,13 @@ faster for `max_tasks >= 4`; all other cases are scaling linearly with the numbe
 ## GPU settings
 The `block_size` parameter controls the number of threads per block and must be a power of two.
 
+The GPU-only `items_per_thread` parameter must be at least 1 and controls how many elements each
+thread reduces in a block-strided pass. Its default is
+`max(2, default_items_per_thread(backend))`; larger values can improve throughput on discrete GPUs.
+
 The `temp` parameter can be used to pass a pre-allocated temporary array. For reduction to a scalar
-(`dims=nothing` or `dims=:`), `length(temp) >= 2 * (length(src) + 2 * block_size - 1) ÷ (2 *
-block_size)` is required. For reduction along dimensions (`dims` is an integer or a collection of
+(`dims=nothing` or `dims=:`), `length(temp) >= 2 * cld(length(src), items_per_thread * block_size)`
+is required. For reduction along dimensions (`dims` is an integer or a collection of
 integers), `temp` is used as the destination array, and thus must have the exact dimensions required - i.e. same
 dimensionwise sizes as `src`, except for the reduced dimension(s) which become 1; there are some
 corner cases when one dimension is zero, check against `Base.reduce` for CPU arrays for exact
@@ -290,6 +300,7 @@ function _mapreduce_impl(
 
     # GPU settings
     block_size::Int=256,
+    items_per_thread::Int=max(2, default_items_per_thread(backend)),
     temp::Union{Nothing, AbstractArray}=nothing,
     switch_below::Int=0,
 )
@@ -306,7 +317,7 @@ function _mapreduce_impl(
                 f, op, src, backend;
                 init, neutral,
                 max_tasks, min_elems,
-                block_size, temp,
+                block_size, items_per_thread, temp,
                 switch_below
             )
         else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,6 +8,9 @@ const CPU_BACKEND = get_backend([])
     return backend != CPU_BACKEND || !prefer_threads
 end
 
+# Backends may request more than the historical default of two items per thread.
+@inline default_items_per_thread(backend) = 1
+
 """
     struct TypeWrap{T} end
     TypeWrap(T) = TypeWrap{T}()

--- a/test/generic/reduce.jl
+++ b/test/generic/reduce.jl
@@ -432,6 +432,23 @@ end
     @test AK.mapreduce(abs, +, array_from_host(vh_one); prefer_threads, init=Int32(10)) ==
         mapreduce(abs, +, vh_one; init=Int32(10))
 
+    if !prefer_threads
+        for len in (65, 257, 1025), items_per_thread in (1, 2, 4)
+            vh = Int32.(mod.(1:len, 17) .- 8)
+            v = array_from_host(vh)
+            for (f, op, neutral) in ((x -> 3x - 1, +, Int32(0)),
+                                     (abs, max, typemin(Int32)),
+                                     (x -> -x, min, typemax(Int32)))
+                @test AK.mapreduce(f, op, v; prefer_threads, init=neutral, neutral,
+                                   block_size=64, items_per_thread) ==
+                    Base.mapreduce(f, op, vh; init=neutral)
+            end
+        end
+
+        @test_throws ArgumentError AK.mapreduce(identity, +, array_from_host(Int32[1, 2]);
+                                                prefer_threads, init=Int32(0), items_per_thread=0)
+    end
+
     vh_typechange = rand(Int32(-10):Int32(10), 4, 5)
     f_typechange = x -> Float32(x) / 2
     @test AK.mapreduce(f_typechange, +, array_from_host(vh_typechange); prefer_threads, init=0f0) ≈


### PR DESCRIPTION
GPU reductions currently process two items per thread. This PR makes that configurable with an items_per_thread keyword and a backend-specific default, while keeping the existing value of two by default.

The kernel uses a straightforward striped load so consecutive threads access consecutive elements. items_per_thread=1 is supported, and tests cover 1, 2, and 4 items per thread with uneven input sizes.

This keeps the useful performance knob without introducing a general tiling abstraction. A reusable block-collectives API can be developed separately when there are more consumers.

On the original RTX 3060 benchmark, using four items per thread reduced the time for a 64M-element Int32 sum from 1.36 ms to 0.85 ms. The benefit is hardware-dependent; K=2 and K=4 perform about the same on an RTX 5080.

Validated with the CUDA and OpenCL reduction test suites.