### PR TITLE
Make GPU scans process multiple items per thread

### DIFF
--- a/src/accumulate/accumulate.jl
+++ b/src/accumulate/accumulate.jl
@@ -44,12 +44,13 @@ include("accumulate_nd.jl")
 
         # GPU settings
         block_size::Int=256,
+        items_per_thread::Union{Nothing, Int}=nothing,
         temp::Union{Nothing, AbstractArray}=nothing,
         temp_flags::Union{Nothing, AbstractArray}=nothing,
     )
 
     accumulate!(
-        op, dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(v);
+        op, dst::AbstractArray, src::AbstractArray, backend::Backend=get_backend(dst);
         init,
         neutral=neutral_element(op, eltype(dst)),
         dims::Union{Nothing, Int}=nothing,
@@ -64,6 +65,7 @@ include("accumulate_nd.jl")
 
         # GPU settings
         block_size::Int=256,
+        items_per_thread::Union{Nothing, Int}=nothing,
         temp::Union{Nothing, AbstractArray}=nothing,
         temp_flags::Union{Nothing, AbstractArray}=nothing,
     )
@@ -99,13 +101,18 @@ For the 1D case (`dims=nothing`), the `alg` can be one of the following:
 
 A different, unique algorithm is used for the multi-dimensional case (`dims` is an integer).
 
-The `block_size` should be a power of 2 and greater than 0.
+The `block_size` should be a power of 2 and greater than 0. `items_per_thread` controls how many
+elements each thread processes per block and does not need to be a power of 2. Its default is at
+most 8, reduced for wide element types to limit shared-memory use.
 
 The temporaries are only used for the 1D case (`dims=nothing`): `temp` stores per-block aggregates;
 `temp_flags` is only used for the `DecoupledLookback()` algorithm for flagging if blocks are ready;
-they should both have at least `(length(v) + 2 * block_size - 1) ÷ (2 * block_size)` elements; also,
-`eltype(v) === eltype(temp)` is required; the elements in `temp_flags` can be any integers, but
-`UInt8` is used by default to reduce memory usage.
+they should both have at least `cld(length(v), block_size * items_per_thread)` elements, using the
+effective default described above when `items_per_thread` is omitted.
+Also, `eltype(v) === eltype(temp)` is required; the elements in `temp_flags` can be any integers,
+but `UInt8` is used by default to reduce memory usage. Multi-block exclusive scans with
+`DecoupledLookback()` use two epilogue kernels to shift the result in place; they reuse `temp` for
+tile-boundary values and do not allocate a full-array copy.
 
 # Examples
 Example computing an inclusive prefix sum (the typical GPU "scan"):
@@ -163,16 +170,21 @@ function _accumulate_impl!(
 
     # GPU settings
     block_size::Int=256,
+    items_per_thread::Union{Nothing, Int}=nothing,
     temp::Union{Nothing, AbstractArray}=nothing,
     temp_flags::Union{Nothing, AbstractArray}=nothing,
 )
     if isnothing(dims)
         return if use_gpu_algorithm(backend, prefer_threads)
+            items_per_thread = something(
+                items_per_thread,
+                default_scan_items_per_thread(backend, eltype(v), block_size),
+            )
             accumulate_1d_gpu!(
                 op, v, backend, alg;
                 init, neutral, inclusive,
                 max_tasks, min_elems,
-                block_size, temp, temp_flags,
+                block_size, items_per_thread, temp, temp_flags,
             )
         else
             accumulate_1d_cpu!(
@@ -210,6 +222,7 @@ end
 
         # GPU settings
         block_size::Int=256,
+        items_per_thread::Union{Nothing, Int}=nothing,
         temp::Union{Nothing, AbstractArray}=nothing,
         temp_flags::Union{Nothing, AbstractArray}=nothing,
     )
@@ -231,4 +244,3 @@ function accumulate(
     )
     vcopy
 end
-

--- a/src/accumulate/accumulate_1d_gpu.jl
+++ b/src/accumulate/accumulate_1d_gpu.jl
@@ -212,7 +212,7 @@ end
 
 
 # Save the value preceding each tile before shifting the array in place.
-@kernel cpu=false inbounds=true unsafe_indices=true function _exclusive_prefixes!(
+@kernel cpu=false inbounds=true unsafe_indices=true function exclusive_prefixes_kernel!(
     prefixes, @Const(v), init, elems_per_block,
 )
     iblock = @index(Global, Linear) - 0x1
@@ -222,7 +222,7 @@ end
 end
 
 
-@kernel cpu=false inbounds=true unsafe_indices=true function _exclusive_shift!(
+@kernel cpu=false inbounds=true unsafe_indices=true function exclusive_shift_kernel!(
     v, @Const(prefixes), ::Val{ITEMS},
 ) where ITEMS
     @uniform block_size = @groupsize()[1]
@@ -317,10 +317,10 @@ function accumulate_1d_gpu!(
     end
 
     if shift_to_exclusive
-        _exclusive_prefixes!(backend, block_size)(prefixes, v, init, elems_per_block,
-                                                  ndrange=num_blocks)
-        _exclusive_shift!(backend, block_size)(v, prefixes, items,
-                                               ndrange=num_blocks * block_size)
+        exclusive_prefixes_kernel!(backend, block_size)(prefixes, v, init, elems_per_block,
+                                                        ndrange=num_blocks)
+        exclusive_shift_kernel!(backend, block_size)(v, prefixes, items,
+                                                     ndrange=num_blocks * block_size)
     end
 
     return v

--- a/src/accumulate/accumulate_1d_gpu.jl
+++ b/src/accumulate/accumulate_1d_gpu.jl
@@ -212,13 +212,11 @@ end
 
 
 # Save the value preceding each tile before shifting the array in place.
-@kernel cpu=false inbounds=true unsafe_indices=true function exclusive_prefixes_kernel!(
+@kernel cpu=false inbounds=true function exclusive_prefixes_kernel!(
     prefixes, @Const(v), init, elems_per_block,
 )
     iblock = @index(Global, Linear) - 0x1
-    if iblock < length(prefixes)
-        prefixes[iblock + 0x1] = iblock == 0x0 ? init : v[iblock * elems_per_block]
-    end
+    prefixes[iblock + 0x1] = iblock == 0x0 ? init : v[iblock * elems_per_block]
 end
 
 

--- a/src/accumulate/accumulate_1d_gpu.jl
+++ b/src/accumulate/accumulate_1d_gpu.jl
@@ -317,8 +317,8 @@ function accumulate_1d_gpu!(
     end
 
     if shift_to_exclusive
-        _exclusive_prefixes!(backend)(prefixes, v, init, elems_per_block,
-                                      ndrange=num_blocks)
+        _exclusive_prefixes!(backend, block_size)(prefixes, v, init, elems_per_block,
+                                                  ndrange=num_blocks)
         _exclusive_shift!(backend, block_size)(v, prefixes, items,
                                                ndrange=num_blocks * block_size)
     end

--- a/src/accumulate/accumulate_1d_gpu.jl
+++ b/src/accumulate/accumulate_1d_gpu.jl
@@ -1,190 +1,154 @@
-const ACC_NUM_BANKS::UInt8 = 32
 const ACC_LOG_NUM_BANKS::UInt8 = 5
 
 const ACC_FLAG_A::UInt8 = 0             # Aggregate of all previous prefixes finished
 const ACC_FLAG_P::UInt8 = 1             # Only current block's prefix available
 
 
+# Bank-conflict-avoiding padding, used by the multi-dimensional scan (accumulate_nd.jl)
 @inline function conflict_free_offset(n)
-    # Two possible offsets
     n >> ACC_LOG_NUM_BANKS
-    # n >> ACC_NUM_BANKS + n >> (2 * ACC_LOG_NUM_BANKS)
 end
 
 
+# Register-raking block scan with striped loads and stores.
 @kernel cpu=false inbounds=true unsafe_indices=true function _accumulate_block!(
     op, v, init, neutral,
     inclusive,
-    flags, prefixes,                # one per block
-)
-    # NOTE: shmem_size MUST be greater than 2 * block_size
-    # NOTE: block_size MUST be a power of 2
-    len = length(v)
+    flags, prefixes,
+    ::Val{ITEMS},
+) where ITEMS
+    # `block_size` is a power of two.
     @uniform block_size = @groupsize()[1]
-    temp = @localmem eltype(v) (0x2 * block_size + conflict_free_offset(0x2 * block_size),)
+    tile = @localmem eltype(v) (block_size * ITEMS,)
+    thread_totals = @localmem eltype(v) (block_size,)
 
-    # NOTE: for many index calculations in this library, computation using zero-indexing leads to
-    # fewer operations (also code is transpiled to CUDA / ROCm / oneAPI / Metal code which do zero
-    # indexing). Internal calculations will be done using zero indexing except when actually
-    # accessing memory. As with C, the lower bound is inclusive, the upper bound exclusive.
-
-    # Group (block) and local (thread) indices
-    iblock = @index(Group, Linear) - 0x1
+    # Internal indices are zero-based; add one only when indexing arrays.
+    len = length(v)
+    iblock  = @index(Group, Linear) - 0x1
     ithread = @index(Local, Linear) - 0x1
+    block_offset = iblock * block_size * ITEMS
 
-    num_blocks = @ndrange()[1] ÷ block_size
-    block_offset = iblock * block_size * 0x2            # Processing two elements per thread
-
-    # Copy two elements from the main array; offset indices to avoid bank conflicts
-    ai = ithread
-    bi = ithread + block_size
-
-    bank_offset_a = conflict_free_offset(ai)
-    bank_offset_b = conflict_free_offset(bi)
-
-    if block_offset + ai < len
-        temp[ai + bank_offset_a + 0x1] = v[block_offset + ai + 0x1]
-    else
-        temp[ai + bank_offset_a + 0x1] = neutral
+    # Load a tile in striped order.
+    j = 0
+    while j < ITEMS
+        p = j * block_size + ithread
+        gi = block_offset + p
+        tile[p + 0x1] = gi < len ? v[gi + 0x1] : neutral
+        j += 1
     end
+    @synchronize()
 
-    if block_offset + bi < len
-        temp[bi + bank_offset_b + 0x1] = v[block_offset + bi + 0x1]
-    else
-        temp[bi + bank_offset_b + 0x1] = neutral
+    # Scan each thread's blocked run.
+    run = ithread * ITEMS
+    acc = neutral
+    k = 0
+    while k < ITEMS
+        acc = op(acc, tile[run + k + 0x1])
+        tile[run + k + 0x1] = acc
+        k += 1
     end
+    thread_totals[ithread + 0x1] = acc
+    @synchronize()
 
-    # Build block reduction down
-    offset = typeof(ithread)(1)
-    next_pow2 = block_size * 0x2
-    d = next_pow2 >> 0x1
-    while d > 0x0             # TODO: unroll this like in reduce.jl ?
+    # Scan the per-thread totals. Later blocks receive their carry from the
+    # second kernel.
+    seed = iblock == 0x0 ? init : neutral
+
+    # Use index-sized counters for block sizes of 256 or more.
+    offset = one(ithread)
+    d = block_size >> 0x1
+    while d > 0x0
         @synchronize()
-
         if ithread < d
-            _ai = offset * (0x2 * ithread + 0x1) - 0x1
-            _bi = offset * (0x2 * ithread + 0x2) - 0x1
-            _ai += conflict_free_offset(_ai)
-            _bi += conflict_free_offset(_bi)
-
-            temp[_bi + 0x1] = op(temp[_bi + 0x1], temp[_ai + 0x1])
+            ai = offset * (0x2 * ithread + 0x1) - 0x1
+            bi = offset * (0x2 * ithread + 0x2) - 0x1
+            thread_totals[bi + 0x1] =
+                op(thread_totals[bi + 0x1], thread_totals[ai + 0x1])
         end
-
         offset = offset << 0x1
         d = d >> 0x1
     end
 
-    # Flush last element
+    @synchronize()
+    block_total = op(seed, thread_totals[block_size])
+    @synchronize()
     if ithread == 0x0
-        offset0 = conflict_free_offset(next_pow2 - 0x1)
-        temp[next_pow2 - 0x1 + offset0 + 0x1] = iblock == 0x0 ? init : neutral
+        thread_totals[block_size] = seed
     end
 
-    # Build block accumulation up
-    d = typeof(ithread)(1)
-    while d < next_pow2
+    # Down-sweep to an exclusive scan.
+    d = one(ithread)
+    while d < block_size
         offset = offset >> 0x1
         @synchronize()
-
         if ithread < d
-            _ai = offset * (0x2 * ithread + 0x1) - 0x1
-            _bi = offset * (0x2 * ithread + 0x2) - 0x1
-            _ai += conflict_free_offset(_ai)
-            _bi += conflict_free_offset(_bi)
-
-            t = temp[_ai + 0x1]
-            temp[_ai + 0x1] = temp[_bi + 0x1]
-            temp[_bi + 0x1] = op(temp[_bi + 0x1], t)
+            ai = offset * (0x2 * ithread + 0x1) - 0x1
+            bi = offset * (0x2 * ithread + 0x2) - 0x1
+            t = thread_totals[ai + 0x1]
+            thread_totals[ai + 0x1] = thread_totals[bi + 0x1]
+            thread_totals[bi + 0x1] = op(thread_totals[bi + 0x1], t)
         end
-
         d = d << 0x1
     end
+    @synchronize()
+    thread_prefix = thread_totals[ithread + 0x1]
 
-    # For exclusive ScanPrefixes scans, the local exclusive output is already correct.
-    # DecoupledLookback still shifts non-first blocks because _accumulate_previous!
-    # expects each block's last value to be globally inclusive.
-    if inclusive || (iblock != 0x0 && !isnothing(flags))
-        # To compute an inclusive scan, shift elements left...
-        @synchronize()
-        t1 = temp[ai + bank_offset_a + 0x1]
-        t2 = temp[bi + bank_offset_b + 0x1]
-        @synchronize()
-
-        if ai > 0x0
-            temp[ai - 0x1 + conflict_free_offset(ai - 0x1) + 0x1] = t1
-        end
-        temp[bi - 0x1 + conflict_free_offset(bi - 0x1) + 0x1] = t2
-
-        # ...and accumulate the last value too
-        if bi == 0x2 * block_size - 0x1
-            if iblock < num_blocks - 0x1
-                temp[bi + bank_offset_b + 0x1] = op(t2, v[(iblock + 0x1) * block_size * 0x2])
-            else
-                temp[bi + bank_offset_b + 0x1] = op(t2, v[len])
-            end
-        end
+    # DecoupledLookback keeps later blocks inclusive until the carry pass.
+    block_inclusive = inclusive || (iblock != 0x0 && !isnothing(flags))
+    prev = neutral
+    k = 0
+    while k < ITEMS
+        r = tile[run + k + 0x1]
+        tile[run + k + 0x1] =
+            block_inclusive ? op(thread_prefix, r) : op(thread_prefix, prev)
+        prev = r
+        k += 1
     end
-
     @synchronize()
 
-    # Write this block's final prefix to global array and set flag to "block prefix computed"
-    if bi == 0x2 * block_size - 0x1
-
-        # Known at compile-time; used in the first pass of the ScanPrefixes algorithm
+    if ithread == 0x0
         if !isnothing(prefixes)
-            if isnothing(flags) && !inclusive
-                last_global = block_offset + bi
-                if last_global < len
-                    prefixes[iblock + 0x1] = op(temp[bi + bank_offset_b + 0x1], v[last_global + 0x1])
-                else
-                    prefixes[iblock + 0x1] = temp[bi + bank_offset_b + 0x1]
-                end
-            else
-                prefixes[iblock + 0x1] = temp[bi + bank_offset_b + 0x1]
-            end
+            prefixes[iblock + 0x1] = block_total
         end
-
-        # Known at compile-time; used only in the DecoupledLookback algorithm
         if !isnothing(flags)
             flags[iblock + 0x1] = ACC_FLAG_P
         end
     end
 
-    if block_offset + ai < len
-        v[block_offset + ai + 0x1] = temp[ai + bank_offset_a + 0x1]
-    end
-    if block_offset + bi < len
-        v[block_offset + bi + 0x1] = temp[bi + bank_offset_b + 0x1]
+    # Store the tile in striped order.
+    j = 0
+    while j < ITEMS
+        p = j * block_size + ithread
+        gi = block_offset + p
+        if gi < len
+            v[gi + 0x1] = tile[p + 0x1]
+        end
+        j += 1
     end
 end
 
 
+# Add each block's running prefix, stopping at a completed predecessor.
 @kernel cpu=false inbounds=true unsafe_indices=true function _accumulate_previous!(
-    op, v, flags, @Const(prefixes),
-)
-
+    op, v, flags, @Const(prefixes), ::Val{ITEMS},
+) where ITEMS
     len = length(v)
-    block_size = @groupsize()[1]
+    @uniform block_size = @groupsize()[1]
 
-    # NOTE: for many index calculations in this library, computation using zero-indexing leads to
-    # fewer operations (also code is transpiled to CUDA / ROCm / oneAPI / Metal code which do zero
-    # indexing). Internal calculations will be done using zero indexing except when actually
-    # accessing memory. As with C, the lower bound is inclusive, the upper bound exclusive.
-
-    # Group (block) and local (thread) indices
-    iblock = @index(Group, Linear) - 0x1 + 0x1              # Skipping first block
+    iblock = @index(Group, Linear)
     ithread = @index(Local, Linear) - 0x1
-    block_offset = iblock * block_size * 0x2                # Processing two elements per thread
+    block_offset = iblock * block_size * ITEMS
 
-    # Each block looks back to find running prefix sum
-    running_prefix = prefixes[iblock - 0x1 + 0x1]
+    running_prefix = prefixes[iblock]
     inspected_block = signed(typeof(iblock))(iblock) - 0x2
     while inspected_block >= 0x0
-        # Opportunistic: a previous block finished everything
-        if UnsafeAtomics.load(pointer(flags, inspected_block + 0x1), UnsafeAtomics.monotonic) == ACC_FLAG_A
-            UnsafeAtomics.fence(UnsafeAtomics.acquire) # (fence before reading from v)
-            # Previous blocks (except last) always have filled values in v, so index is inbounds
-            running_prefix = op(running_prefix, v[(inspected_block + 0x1) * block_size * 0x2])
+        flag = UnsafeAtomics.load(
+            pointer(flags, inspected_block + 0x1),
+            UnsafeAtomics.monotonic,
+        )
+        if flag == ACC_FLAG_A
+            UnsafeAtomics.fence(UnsafeAtomics.acquire)
+            running_prefix = op(running_prefix, v[(inspected_block + 0x1) * block_size * ITEMS])
             break
         else
             running_prefix = op(running_prefix, prefixes[inspected_block + 0x1])
@@ -193,73 +157,101 @@ end
         inspected_block -= 0x1
     end
 
-    # Now we have aggregate prefix of all previous blocks, add it to all our elements
-    ai = ithread
-    if block_offset + ai < len
-        v[block_offset + ai + 0x1] = op(running_prefix, v[block_offset + ai + 0x1])
+    # Add the aggregate prefix of all previous blocks to each element.
+    j = 0
+    while j < ITEMS
+        gi = block_offset + j * block_size + ithread
+        if gi < len
+            v[gi + 0x1] = op(running_prefix, v[gi + 0x1])
+        end
+        j += 1
     end
 
-    bi = ithread + block_size
-    if block_offset + bi < len
-        v[block_offset + bi + 0x1] = op(running_prefix, v[block_offset + bi + 0x1])
-    end
-
-    # Set flag for "aggregate of all prefixes up to this block finished"
-    # There are two synchronization concerns here:
-    # 1. Withing a group we want to ensure that all writed to `v` have occured before setting the flag.
-    # 2. Between groups we need to use a fence and atomic load/store to ensure that memory operations are not re-ordered
-    @synchronize() # within-block
-    # Note: This fence is needed to ensure that the flag is not set before copying into v.
-    #       See https://doc.rust-lang.org/std/sync/atomic/fn.fence.html
-    #       for more details.
-    #       We use the happens-before relation between stores to `v` and the store to `flags`.
+    # Publish writes to `v` before marking the block complete.
+    @synchronize()
     UnsafeAtomics.fence(UnsafeAtomics.release)
     if ithread == 0x0
-        UnsafeAtomics.store!(pointer(flags, iblock + 0x1), convert(eltype(flags), ACC_FLAG_A), UnsafeAtomics.monotonic)
+        UnsafeAtomics.store!(
+            pointer(flags, iblock + 0x1),
+            convert(eltype(flags), ACC_FLAG_A),
+            UnsafeAtomics.monotonic,
+        )
     end
 end
 
 
+# Add pre-scanned block prefixes to each tile.
 @kernel cpu=false inbounds=true unsafe_indices=true function _accumulate_previous_coupled_preblocks!(
-    op, v, prefixes,
-)
-    # No decoupled lookback
+    op, v, prefixes, ::Val{ITEMS},
+) where ITEMS
     len = length(v)
-    block_size = @groupsize()[1]
+    @uniform block_size = @groupsize()[1]
 
-    # NOTE: for many index calculations in this library, computation using zero-indexing leads to
-    # fewer operations (also code is transpiled to CUDA / ROCm / oneAPI / Metal code which do zero
-    # indexing). Internal calculations will be done using zero indexing except when actually
-    # accessing memory. As with C, the lower bound is inclusive, the upper bound exclusive.
-
-    # Group (block) and local (thread) indices
-    iblock = @index(Group, Linear) - 0x1 + 0x1              # Skipping first block
+    iblock = @index(Group, Linear)
     ithread = @index(Local, Linear) - 0x1
-    block_offset = iblock * block_size * 0x2                # Processing two elements per thread
+    block_offset = iblock * block_size * ITEMS
 
-    # Each block looks back to find running prefix sum
-    running_prefix = prefixes[iblock - 0x1 + 0x1]
+    running_prefix = prefixes[iblock]
 
-    # The prefixes were pre-accumulated, which means (for block_size=N):
-    #   - If there were N or fewer prefixes (so fewer than N*N elements in v to begin with), the
-    #     prefixes were fully accumulated and we can use them directly.
-    #   - If there were more than N prefixes, each chunk of N prefixes was accumulated, but not
-    #     along the chunks. We need to accumulate the prefixes of the previous chunks into
-    #     running_prefix.
-    num_preblocks = (iblock - 0x1) ÷ (block_size * 0x2)
+    # If there were more than `block_size*ITEMS` prefixes, each chunk was scanned
+    # internally but not across chunks; fold the earlier chunks' totals in here.
+    num_preblocks = (iblock - 0x1) ÷ (block_size * ITEMS)
     for i in 0x1:num_preblocks
-        running_prefix = op(running_prefix, prefixes[i * block_size * 0x2])
+        running_prefix = op(running_prefix, prefixes[i * block_size * ITEMS])
     end
 
-    # Now we have aggregate prefix of all previous blocks, add it to all our elements
-    ai = ithread
-    if block_offset + ai < len
-        v[block_offset + ai + 0x1] = op(running_prefix, v[block_offset + ai + 0x1])
+    j = 0
+    while j < ITEMS
+        gi = block_offset + j * block_size + ithread
+        if gi < len
+            v[gi + 0x1] = op(running_prefix, v[gi + 0x1])
+        end
+        j += 1
     end
+end
 
-    bi = ithread + block_size
-    if block_offset + bi < len
-        v[block_offset + bi + 0x1] = op(running_prefix, v[block_offset + bi + 0x1])
+
+# Save the value preceding each tile before shifting the array in place.
+@kernel cpu=false inbounds=true unsafe_indices=true function _exclusive_prefixes!(
+    prefixes, @Const(v), init, elems_per_block,
+)
+    iblock = @index(Global, Linear) - 0x1
+    if iblock < length(prefixes)
+        prefixes[iblock + 0x1] = iblock == 0x0 ? init : v[iblock * elems_per_block]
+    end
+end
+
+
+@kernel cpu=false inbounds=true unsafe_indices=true function _exclusive_shift!(
+    v, @Const(prefixes), ::Val{ITEMS},
+) where ITEMS
+    @uniform block_size = @groupsize()[1]
+    tile = @localmem eltype(v) (block_size * ITEMS,)
+
+    len = length(v)
+    iblock = @index(Group, Linear) - 0x1
+    ithread = @index(Local, Linear) - 0x1
+    block_offset = iblock * block_size * ITEMS
+
+    j = 0
+    while j < ITEMS
+        p = j * block_size + ithread
+        gi = block_offset + p
+        if gi < len
+            tile[p + 0x1] = v[gi + 0x1]
+        end
+        j += 1
+    end
+    @synchronize()
+
+    j = 0
+    while j < ITEMS
+        p = j * block_size + ithread
+        gi = block_offset + p
+        if gi < len
+            v[gi + 0x1] = p == 0x0 ? prefixes[iblock + 0x1] : tile[p]
+        end
+        j += 1
     end
 end
 
@@ -277,28 +269,30 @@ function accumulate_1d_gpu!(
 
     # GPU settings
     block_size::Int,
+    items_per_thread::Int,
     temp::Union{Nothing, AbstractArray},
     temp_flags::Union{Nothing, AbstractArray},
 )
     # Correctness checks
     @argcheck block_size > 0
     @argcheck ispow2(block_size)
+    @argcheck items_per_thread > 0
 
     # Nothing to accumulate
     if length(v) == 0
         return v
     end
 
-    # Each thread will process two elements
-    elems_per_block = block_size * 2
+    elems_per_block = block_size * items_per_thread
     num_blocks = (length(v) + elems_per_block - 1) ÷ elems_per_block
+    items = Val(items_per_thread)
 
     if isnothing(temp)
         prefixes = similar(v, eltype(v), num_blocks)
     else
         @argcheck eltype(temp) === eltype(v)
         @argcheck length(temp) >= num_blocks
-        prefixes = temp
+        prefixes = view(temp, 1:num_blocks)
     end
 
     if isnothing(temp_flags)
@@ -306,17 +300,27 @@ function accumulate_1d_gpu!(
     else
         @argcheck eltype(temp_flags) <: Integer
         @argcheck length(temp_flags) >= num_blocks
-        flags = temp_flags
+        flags = view(temp_flags, 1:num_blocks)
     end
 
+    shift_to_exclusive = !inclusive && num_blocks > 1
+    block_inclusive = inclusive || shift_to_exclusive
+
     kernel1! = _accumulate_block!(backend, block_size)
-    kernel1!(op, v, init, neutral, inclusive, flags, prefixes,
+    kernel1!(op, v, init, neutral, block_inclusive, flags, prefixes, items,
              ndrange=num_blocks * block_size)
 
     if num_blocks > 1
         kernel2! = _accumulate_previous!(backend, block_size)
-        kernel2!(op, v, flags, prefixes,
+        kernel2!(op, v, flags, prefixes, items,
                  ndrange=(num_blocks - 1) * block_size)
+    end
+
+    if shift_to_exclusive
+        _exclusive_prefixes!(backend)(prefixes, v, init, elems_per_block,
+                                      ndrange=num_blocks)
+        _exclusive_shift!(backend, block_size)(v, prefixes, items,
+                                               ndrange=num_blocks * block_size)
     end
 
     return v
@@ -336,45 +340,47 @@ function accumulate_1d_gpu!(
 
     # GPU settings
     block_size::Int,
+    items_per_thread::Int,
     temp::Union{Nothing, AbstractArray},
     temp_flags::Union{Nothing, AbstractArray},
 )
     # Correctness checks
     @argcheck block_size > 0
     @argcheck ispow2(block_size)
+    @argcheck items_per_thread > 0
 
     # Nothing to accumulate
     if length(v) == 0
         return v
     end
 
-    # Each thread will process two elements
-    elems_per_block = block_size * 2
+    elems_per_block = block_size * items_per_thread
     num_blocks = (length(v) + elems_per_block - 1) ÷ elems_per_block
+    items = Val(items_per_thread)
 
     if isnothing(temp)
         prefixes = similar(v, eltype(v), num_blocks)
     else
         @argcheck eltype(temp) === eltype(v)
         @argcheck length(temp) >= num_blocks
-        prefixes = temp
+        prefixes = view(temp, 1:num_blocks)
     end
 
     kernel1! = _accumulate_block!(backend, block_size)
-    kernel1!(op, v, init, neutral, inclusive, nothing, prefixes,
+    kernel1!(op, v, init, neutral, inclusive, nothing, prefixes, items,
              ndrange=num_blocks * block_size)
 
     if num_blocks > 1
 
         # Accumulate prefixes of all blocks; use neutral as init here to not reinclude init
         num_blocks_prefixes = (length(prefixes) + elems_per_block - 1) ÷ elems_per_block
-        kernel1!(op, prefixes, neutral, neutral, true, nothing, nothing,
+        kernel1!(op, prefixes, neutral, neutral, true, nothing, nothing, items,
                  ndrange=num_blocks_prefixes * block_size)
 
         # Prefixes are pre-accumulated (completely accumulated if num_blocks_prefixes == 1, or
         # partially, which we will account for in the coupled lookback)
         kernel2! = _accumulate_previous_coupled_preblocks!(backend, block_size)
-        kernel2!(op, v, prefixes,
+        kernel2!(op, v, prefixes, items,
                  ndrange=(num_blocks - 1) * block_size)
     end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,6 +11,16 @@ end
 # Backends may request more than the historical default of two items per thread.
 @inline default_items_per_thread(backend) = 1
 
+# Elements each thread scans in the GPU prefix-scan block kernel.
+@inline default_scan_items_per_thread(backend) = 8
+
+# Keep the default shared-memory use within the 32 KiB OpenCL/Metal baseline.
+@inline function default_scan_items_per_thread(backend, ::Type{T}, block_size) where T
+    block_size > 0 || return default_scan_items_per_thread(backend)
+    max_items = max(1, 32 * 1024 ÷ (block_size * max(sizeof(T), 1)) - 1)
+    min(default_scan_items_per_thread(backend), max_items)
+end
+
 """
     struct TypeWrap{T} end
     TypeWrap(T) = TypeWrap{T}()

--- a/test/generic/accumulate.jl
+++ b/test/generic/accumulate.jl
@@ -6,7 +6,7 @@ TEST_DL && push!(ALGS, AK.DecoupledLookback())
 
     Random.seed!(0)
 
-    # Single block exlusive scan (each block processes two elements)
+    # Single-block exclusive scan
     for num_elems in 1:256
         x = array_from_host(ones(Int32, num_elems))
         y = copy(x)
@@ -33,21 +33,25 @@ TEST_DL && push!(ALGS, AK.DecoupledLookback())
         @test all(yh .== 0:length(yh) - 1)
     end
 
-    # Non-uniform data exposes ScanPrefixes block-carry bugs that all-ones data masks.
-    # NOTE: DecoupledLookback() is excluded here: its exclusive multi-block carries are still
-    # incorrect on non-uniform data (the all-ones exclusive tests above mask that bug). Fixing it
-    # requires a coherent cross-block aggregate publish that is tracked separately.
-    if alg isa AK.ScanPrefixes
-        for _ in 1:200
+    # Non-uniform data exposes block-carry bugs that all-ones data masks.
+    for items_per_thread in (1, 3, 8)
+        for _ in 1:50
             num_elems = rand(513:100_000)
             block_size = rand([16, 32, 64, 128, 256])
             init = rand(Int32(-100):Int32(100))
             xh = rand(Int32(-9):Int32(9), num_elems)
             y = array_from_host(xh)
-            AK.accumulate!(+, y; prefer_threads, init, inclusive=false, block_size, alg)
+            AK.accumulate!(+, y; prefer_threads, init, inclusive=false, block_size,
+                           items_per_thread, alg)
             @test Array(y) == (cumsum(xh) .- xh) .+ init
         end
     end
+
+    # The default limits shared-memory use for wide element types.
+    xh = ComplexF64.(1:4097)
+    y = array_from_host(xh)
+    AK.accumulate!(+, y; prefer_threads, init=0.0 + 0.0im, alg)
+    @test Array(y) == cumsum(xh)
 
     # Large inclusive scan
     for _ in 1:1000
@@ -104,15 +108,18 @@ TEST_DL && push!(ALGS, AK.DecoupledLookback())
     # Test that undefined kwargs are not accepted
     @test_throws MethodError AK.accumulate(+, y; prefer_threads, init=10, dims=2, inclusive=false, bad=:kwarg)
 
-    # Testing different settings
-    AK.accumulate!(+, array_from_host(ones(Int32, 1000)); init=0, inclusive=false,
-                prefer_threads, block_size=128, alg,
-                temp=array_from_host(zeros(Int32, 1000)),
-                temp_flags=array_from_host(zeros(Int8, 1000)))
-    AK.accumulate(+, array_from_host(ones(Int32, 1000)); init=0, inclusive=false,
-                prefer_threads, block_size=128, alg,
-                temp=array_from_host(zeros(Int64, 1000)),
-                temp_flags=array_from_host(zeros(Int8, 1000)))
+    # Oversized temporaries are allowed.
+    y = array_from_host(ones(Int32, 1000))
+    AK.accumulate!(+, y; init=0, inclusive=false, prefer_threads, block_size=128, alg,
+                   temp=array_from_host(zeros(Int32, 1000)),
+                   temp_flags=array_from_host(zeros(Int8, 1000)))
+    @test Array(y) == 0:999
+
+    y = AK.accumulate(+, array_from_host(ones(Int32, 1000)); init=0, inclusive=false,
+                      prefer_threads, block_size=128, alg,
+                      temp=array_from_host(zeros(Int64, 1000)),
+                      temp_flags=array_from_host(zeros(Int8, 1000)))
+    @test Array(y) == 0:999
 end
 
 

--- a/test/generic/accumulate.jl
+++ b/test/generic/accumulate.jl
@@ -48,10 +48,12 @@ TEST_DL && push!(ALGS, AK.DecoupledLookback())
     end
 
     # The default limits shared-memory use for wide element types.
-    xh = ComplexF64.(1:4097)
-    y = array_from_host(xh)
-    AK.accumulate!(+, y; prefer_threads, init=0.0 + 0.0im, alg)
-    @test Array(y) == cumsum(xh)
+    if KernelAbstractions.supports_float64(BACKEND)
+        xh = ComplexF64.(1:4097)
+        y = array_from_host(xh)
+        AK.accumulate!(+, y; prefer_threads, init=0.0 + 0.0im, alg)
+        @test Array(y) == cumsum(xh)
+    end
 
     # Large inclusive scan
     for _ in 1:1000


### PR DESCRIPTION
GPU scans currently process two items per thread. This PR makes that configurable with an `items_per_thread` keyword and uses eight by default where the element type fits within the 32 KiB shared-memory baseline. The value does not need to be a power of two.

Each thread scans a blocked run after a coalesced load, then the block scans the per-thread totals. On an RTX 5080 with 64M `Int32` elements, this reduced `ScanPrefixes` from 2.00 ms to 1.31 ms and `DecoupledLookback` from 10.4 ms to 3.8 ms.

This also fixes multi-block exclusive `DecoupledLookback` scans. After inclusive carry propagation, two epilogue kernels save one boundary value per tile and shift each tile in place; no full-array temporary is allocated. `ScanPrefixes` remains the default.

Validated with the CUDA and OpenCL accumulate test suites.